### PR TITLE
chore: adding dynamic dependency resolution support.

### DIFF
--- a/aws-greengrass-testing-features/pom.xml
+++ b/aws-greengrass-testing-features/pom.xml
@@ -38,10 +38,21 @@
             <version>1</version>
         </dependency>
         <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>aws-greengrass-testing-modules</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <version>${auto.service.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
         </dependency>
         <dependency>
             <groupId>org.immutables</groupId>

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
@@ -9,13 +9,13 @@ import software.amazon.awssdk.services.iam.IamClient;
 import javax.inject.Inject;
 
 @AutoService(AWSResourceLifecycle.class)
-public class IamRoleLifecycle extends AbstractAWSResourceLifecycle<IamClient> {
+public class IamLifecycle extends AbstractAWSResourceLifecycle<IamClient> {
     @Inject
-    public IamRoleLifecycle(IamClient client) {
+    public IamLifecycle(IamClient client) {
         super(client, IamRoleSpec.class);
     }
 
-    public IamRoleLifecycle() {
+    public IamLifecycle() {
         this(IamClient.builder().build());
     }
 }

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iam/IamModule.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iam/IamModule.java
@@ -1,0 +1,22 @@
+package com.aws.greengrass.testing.resources.iam;
+
+import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;
+import com.google.auto.service.AutoService;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.iam.IamClient;
+
+import javax.inject.Singleton;
+
+@AutoService(Module.class)
+public class IamModule extends AbstractAWSResourceModule<IamClient, IamLifecycle> {
+    @Provides
+    @Singleton
+    @Override
+    protected IamClient providesClient(AwsCredentialsProvider provider) {
+        return IamClient.builder()
+                .credentialsProvider(provider)
+                .build();
+    }
+}

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iot/IotModule.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/resources/iot/IotModule.java
@@ -1,0 +1,22 @@
+package com.aws.greengrass.testing.resources.iot;
+
+import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;
+import com.google.auto.service.AutoService;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.iot.IotClient;
+
+import javax.inject.Singleton;
+
+@AutoService(Module.class)
+public class IotModule extends AbstractAWSResourceModule<IotClient, IotLifecycle> {
+    @Singleton
+    @Provides
+    @Override
+    protected IotClient providesClient(AwsCredentialsProvider provider) {
+        return IotClient.builder()
+                .credentialsProvider(provider)
+                .build();
+    }
+}

--- a/aws-greengrass-testing-modules/pom.xml
+++ b/aws-greengrass-testing-modules/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>aws-greengrass-testing</artifactId>
+        <groupId>com.aws.greengrass</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aws-greengrass-testing-modules</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>aws-greengrass-testing-resources</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-guice</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto.service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -1,0 +1,36 @@
+package com.aws.greengrass.testing.modules;
+
+import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
+import com.aws.greengrass.testing.resources.AWSResources;
+import com.google.auto.service.AutoService;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.multibindings.Multibinder;
+import io.cucumber.guice.ScenarioScoped;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import javax.inject.Singleton;
+import java.util.Set;
+
+@AutoService(Module.class)
+public class AWSResourcesModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder<AWSResourceLifecycle> lifecycles = Multibinder.newSetBinder(binder(), AWSResourceLifecycle.class);
+        lifecycles.addBinding().in(ScenarioScoped.class);
+    }
+
+    @Provides
+    @ScenarioScoped
+    static AWSResources providesAWSResources(Set<AWSResourceLifecycle> lifecycles) {
+        return new AWSResources(lifecycles);
+    }
+
+    @Provides
+    @Singleton
+    static AwsCredentialsProvider providesAwsCredentialsProvider() {
+        return DefaultCredentialsProvider.create();
+    }
+}

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AbstractAWSResourceModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AbstractAWSResourceModule.java
@@ -1,0 +1,18 @@
+package com.aws.greengrass.testing.modules;
+
+import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import io.cucumber.guice.ScenarioScoped;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+public abstract class AbstractAWSResourceModule<C, U extends AWSResourceLifecycle<C>> extends AbstractModule {
+
+    protected abstract C providesClient(AwsCredentialsProvider provider);
+
+    @ProvidesIntoSet
+    @ScenarioScoped
+    protected AWSResourceLifecycle providesLifeCycle(U lifecycle) {
+        return lifecycle;
+    }
+}

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/GreengrassInjectorSource.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/GreengrassInjectorSource.java
@@ -1,0 +1,36 @@
+package com.aws.greengrass.testing.modules;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.cucumber.guice.CucumberModules;
+import io.cucumber.guice.InjectorSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class GreengrassInjectorSource implements InjectorSource {
+
+    protected Spliterator<Module> providedModules() {
+        return Spliterators.spliteratorUnknownSize(ServiceLoader.load(Module.class).iterator(), Spliterator.NONNULL);
+    }
+
+    private Module[] obtainSystemModules() {
+        return Stream.concat(defaultModules().stream(), StreamSupport.stream(providedModules(), false))
+                .toArray(Module[]::new);
+    }
+
+    protected List<Module> defaultModules() {
+        return Arrays.asList(CucumberModules.createScenarioModule());
+    }
+
+    @Override
+    public Injector getInjector() {
+        return Guice.createInjector(obtainSystemModules());
+    }
+}

--- a/aws-greengrass-testing-modules/src/main/resources/cucumber.properties
+++ b/aws-greengrass-testing-modules/src/main/resources/cucumber.properties
@@ -1,0 +1,1 @@
+guice.injector-source=com.aws.greengrass.testing.modules.GreengrassInjectorSource

--- a/aws-greengrass-testing-resources/src/main/java/com/aws/greengrass/testing/resources/AWSResources.java
+++ b/aws-greengrass-testing-resources/src/main/java/com/aws/greengrass/testing/resources/AWSResources.java
@@ -5,9 +5,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -16,9 +16,9 @@ import java.util.stream.StreamSupport;
 
 public final class AWSResources implements Closeable {
     private static final Logger LOGGER = LogManager.getLogger(AWSResources.class);
-    private final List<AWSResourceLifecycle<?>> lifecycles;
+    private final Set<AWSResourceLifecycle> lifecycles;
 
-    public AWSResources(List<AWSResourceLifecycle<?>> lifecycles) {
+    public AWSResources(Set<AWSResourceLifecycle> lifecycles) {
         this.lifecycles = lifecycles;
     }
 
@@ -27,7 +27,7 @@ public final class AWSResources implements Closeable {
                 Spliterators.spliteratorUnknownSize(
                         ServiceLoader.load(AWSResourceLifecycle.class).iterator(), Spliterator.DISTINCT), false)
                 .map(awsResourceLifecycle -> (AWSResourceLifecycle<?>) awsResourceLifecycle)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toSet()));
     }
 
     public <U extends AWSResourceLifecycle> U lifecycle(Class<U> lifecycleType) {

--- a/aws-greengrass-testing-resources/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLifecycle<C> {
@@ -47,5 +48,21 @@ public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLife
             resource.remove(client);
             iterator.remove();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractAWSResourceLifecycle<?> that = (AbstractAWSResourceLifecycle<?>) o;
+        return Objects.equals(client, that.client)
+                && Objects.equals(specClasses, that.specClasses)
+                && Objects.equals(specs, that.specs)
+                && Objects.equals(resources, that.resources);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(client, specClasses, specs, resources);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>aws-greengrass-testing-features</module>
         <module>aws-greengrass-testing-api</module>
         <module>aws-greengrass-testing-platform</module>
+        <module>aws-greengrass-testing-modules</module>
     </modules>
 
     <properties>
@@ -33,6 +34,7 @@
         <aws.sdk.version>2.16.52</aws.sdk.version>
         <auto.service.version>1.0</auto.service.version>
         <findbugs.version>3.0.2</findbugs.version>
+        <guice.version>5.0.1</guice.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
*Issue #, if available:*

Injector source support.

*Description of changes:*

In addition to support what was already there, the `modules` maven module supports *dynamic* module loading. This allows customers to localize their dependency resolution in the framework of their choosing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
