### PR TITLE
chore: Adding a tracker for extensions that report on it.

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/TestRuns.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/TestRuns.java
@@ -1,0 +1,11 @@
+package com.aws.greengrass.testing.api;
+
+import com.aws.greengrass.testing.api.model.TestRun;
+
+import java.util.List;
+
+public interface TestRuns {
+    List<TestRun> tracking();
+
+    void track(TestRun run);
+}

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
@@ -1,0 +1,33 @@
+package com.aws.greengrass.testing.api.model;
+
+import org.immutables.value.Value;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+
+@TestingModel
+@Value.Immutable
+interface TestRunModel {
+    String name();
+
+    @Nullable
+    Duration duration();
+
+    @Nullable
+    String message();
+
+    @Value.Default
+    default boolean skipped() {
+        return false;
+    }
+
+    @Value.Default
+    default boolean failed() {
+        return false;
+    }
+
+    @Value.Default
+    default boolean passed() {
+        return false;
+    }
+}

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
@@ -1,0 +1,26 @@
+package com.aws.greengrass.testing;
+
+import com.aws.greengrass.testing.api.TestRuns;
+import com.aws.greengrass.testing.api.model.TestRun;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ScenarioTestRuns implements TestRuns {
+    private final List<TestRun> scenarios;
+
+    public ScenarioTestRuns() {
+        scenarios = new ArrayList<>();
+    }
+
+    @Override
+    public List<TestRun> tracking() {
+        return Collections.unmodifiableList(scenarios);
+    }
+
+    @Override
+    synchronized public void track(TestRun run) {
+        scenarios.add(run);
+    }
+}

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
@@ -1,0 +1,46 @@
+package com.aws.greengrass.testing.features;
+
+import com.aws.greengrass.testing.api.TestRuns;
+import com.aws.greengrass.testing.api.model.TestRun;
+import io.cucumber.guice.ScenarioScoped;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+
+import javax.inject.Inject;
+import java.time.Duration;
+
+@ScenarioScoped
+public class ScenarioTrackerSteps {
+    private final TestRuns scenarios;
+    private long startTime;
+
+    @Inject
+    public ScenarioTrackerSteps(final TestRuns scenarios) {
+        this.scenarios = scenarios;
+    }
+
+    @Before
+    public void start(Scenario scenario) {
+        this.startTime = System.currentTimeMillis();
+    }
+
+    @After
+    public void stop(Scenario scenario) {
+        long duration = System.currentTimeMillis() - startTime;
+        TestRun.Builder builder = TestRun.builder()
+                .duration(Duration.ofMillis(duration))
+                .name(scenario.getName());
+        switch (scenario.getStatus()) {
+            case SKIPPED:
+                builder.skipped(true);
+                break;
+            case PASSED:
+                builder.passed(true);
+                break;
+            default:
+                builder.failed(true);
+        }
+        scenarios.track(builder.build());
+    }
+}

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -1,5 +1,7 @@
 package com.aws.greengrass.testing.modules;
 
+import com.aws.greengrass.testing.ScenarioTestRuns;
+import com.aws.greengrass.testing.api.TestRuns;
 import com.aws.greengrass.testing.api.model.TestId;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
@@ -9,6 +11,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import io.cucumber.guice.ScenarioScoped;
 
+import javax.inject.Singleton;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
@@ -26,6 +29,11 @@ public class TestContextModule extends AbstractModule {
         return new BigInteger(1, bytes).toString(16);
     }
 
+    @Provides
+    @Singleton
+    static TestRuns providesTestRunTracker() {
+        return new ScenarioTestRuns();
+    }
 
     @Provides
     @ScenarioScoped


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Certain integrations (ie: IDT) require an aggregate submission of the test results. Adding a global `TestRuns` tracker to be used in conjunction with test frameworks and orchestration layers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
