### PR TITLE
fix: Adding a local files decorator to short circuit to Java files.

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -49,7 +49,7 @@ public class LocalDevice implements Device {
         });
         Optional.ofNullable(input.workingDirectory()).map(Path::toFile).ifPresent(builder::directory);
         try {
-            LOGGER.debug("Runninng process: {}", builder.command());
+            LOGGER.debug("Running process: {}", builder.command());
             final Process process = builder.start();
             if (Objects.isNull(input.timeout())) {
                 process.waitFor();

--- a/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -13,7 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ScenarioScoped
 public class FileSteps {
-    private static final long DEFAULT_TIMEOUT = 10L;
+    private static final long DEFAULT_INTERVAL = 100L;
+    private static final long DEFAULT_TIMEOUT = 30L;
     private final Device device;
     private final Platform platform;
     private final TestContext testContext;
@@ -43,13 +44,14 @@ public class FileSteps {
     public void containsTimeout(String file, String contents, long seconds) throws InterruptedException {
         checkFileExists(file);
         boolean found = false;
+        long startTime = System.currentTimeMillis();
         do {
             found = platform.files().readString(testContext.testDirectory().resolve(file)).contains(contents);
             if (found) {
                 break;
             }
-            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds));
-        } while (!found);
+            Thread.sleep(DEFAULT_INTERVAL);
+        } while (System.currentTimeMillis() - startTime < TimeUnit.SECONDS.toMillis(seconds));
         assertTrue(found, "file " + file + " did not contain " + contents);
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
@@ -1,0 +1,53 @@
+package com.aws.greengrass.testing.platform;
+
+import com.aws.greengrass.testing.api.device.Device;
+import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class DevicePredicatePlatformFiles implements PlatformFiles {
+    private static final Logger LOGGER = LogManager.getLogger(DevicePredicatePlatformFiles.class);
+    private final Device device;
+    private final PlatformFiles left;
+    private final PlatformFiles right;
+    private final Predicate<Device> isLeft;
+
+    public DevicePredicatePlatformFiles(
+            final Predicate<Device> isLeft,
+            final Device device,
+            final PlatformFiles left,
+            final PlatformFiles right) {
+        this.isLeft = isLeft;
+        this.device = device;
+        this.left = left;
+        this.right = right;
+    }
+
+    public static PlatformFiles localOrRemote(final Device device, final PlatformFiles remote) {
+        return new DevicePredicatePlatformFiles(d -> d.type().equals("LOCAL"), device, new LocalFiles(), remote);
+    }
+
+    private <T> T delegate(Function<PlatformFiles, T> thunk) {
+        PlatformFiles files = right;
+        if (isLeft.test(device)) {
+            files = left;
+        }
+        LOGGER.debug("Using file provider {}", files);
+        return thunk.apply(files);
+    }
+
+    @Override
+    public byte[] readBytes(Path filePath) throws CommandExecutionException {
+        return delegate(files -> files.readBytes(filePath));
+    }
+
+    @Override
+    public List<Path> listContents(Path filePath) throws CommandExecutionException {
+        return delegate(files -> files.listContents(filePath));
+    }
+}

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
@@ -1,0 +1,39 @@
+package com.aws.greengrass.testing.platform;
+
+import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
+import com.aws.greengrass.testing.api.device.model.CommandInput;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class LocalFiles implements PlatformFiles {
+    @Override
+    public byte[] readBytes(Path filePath) throws CommandExecutionException {
+        try {
+            return Files.readAllBytes(filePath);
+        } catch (IOException e) {
+            throw new CommandExecutionException(e, CommandInput.of("read: " + filePath));
+        }
+    }
+
+    @Override
+    public List<Path> listContents(Path filePath) throws CommandExecutionException {
+        if (Files.isRegularFile(filePath)) {
+            return Arrays.asList(filePath);
+        }
+        try (Stream<Path> files = Files.walk(filePath)) {
+            return files.sorted(Comparator.reverseOrder())
+                    .filter(Files::isRegularFile)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new CommandExecutionException(e, CommandInput.of("listContents: " + filePath));
+        }
+    }
+}

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
@@ -1,6 +1,7 @@
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.api.device.Device;
+import com.aws.greengrass.testing.platform.DevicePredicatePlatformFiles;
 import com.aws.greengrass.testing.platform.Platform;
 import com.aws.greengrass.testing.platform.PlatformFiles;
 import com.google.auto.service.AutoService;
@@ -20,6 +21,6 @@ public class LinuxPlatform implements Platform {
 
     @Override
     public PlatformFiles files() {
-        return new LinuxFiles(commands());
+        return DevicePredicatePlatformFiles.localOrRemote(device, new LinuxFiles(commands()));
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
@@ -1,6 +1,7 @@
 package com.aws.greengrass.testing.platform.macos;
 
 import com.aws.greengrass.testing.api.device.Device;
+import com.aws.greengrass.testing.platform.DevicePredicatePlatformFiles;
 import com.aws.greengrass.testing.platform.Platform;
 import com.aws.greengrass.testing.platform.PlatformFiles;
 import com.google.auto.service.AutoService;
@@ -20,6 +21,6 @@ public class MacosPlatform implements Platform {
 
     @Override
     public PlatformFiles files() {
-        return new MacosFiles(commands());
+        return DevicePredicatePlatformFiles.localOrRemote(device, new MacosFiles(commands()));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If the active `Device` is local, delegate to Java FS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
