### PR TITLE
feat: Optionally leave generated things for debugging purposes.

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
@@ -1,0 +1,36 @@
+package com.aws.greengrass.testing.api.model;
+
+import org.immutables.value.Value;
+
+import java.util.Collection;
+
+
+@Value.Immutable
+@Value.Style(jdkOnly = true, visibility = Value.Style.ImplementationVisibility.PACKAGE)
+public abstract class CleanupContext {
+    @Value.Default
+    public boolean persistAWSResources() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean persistInstalledSofware() {
+        return false;
+    }
+
+    @Value.Default
+    public boolean persistGeneratedFiles() {
+        return false;
+    }
+
+    public static ImmutableCleanupContext.Builder builder() {
+        return ImmutableCleanupContext.builder();
+    }
+
+    public static CleanupContext fromModes(Collection<PersistMode> modes) {
+        return modes.stream()
+                .reduce(CleanupContext.builder(),
+                        (builder, mode) -> mode.apply(builder),
+                        (left, right) -> left).build();
+    }
+}

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
@@ -1,0 +1,37 @@
+package com.aws.greengrass.testing.api.model;
+
+import java.util.Arrays;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public enum PersistMode implements Function<ImmutableCleanupContext.Builder, ImmutableCleanupContext.Builder> {
+    AWS_RESOURCES(ImmutableCleanupContext.Builder::persistAWSResources),
+    INSTALLED_SOFTWARE(ImmutableCleanupContext.Builder::persistInstalledSofware),
+    GENERATED_FILES(ImmutableCleanupContext.Builder::persistGeneratedFiles);
+
+    BiFunction<ImmutableCleanupContext.Builder, Boolean, ImmutableCleanupContext.Builder> applicator;
+
+    PersistMode(BiFunction<ImmutableCleanupContext.Builder, Boolean, ImmutableCleanupContext.Builder> applicator) {
+        this.applicator = applicator;
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase().replace('_', '.');
+    }
+
+    public static PersistMode fromConfig(String value) {
+        for (PersistMode mode : values()) {
+            if (mode.equals(PersistMode.valueOf(value.replace('.', '_').toUpperCase()))) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException("Could not find a persist value mode for " + value
+                + ". Use any or all: " + Arrays.toString(values()));
+    }
+
+    @Override
+    public ImmutableCleanupContext.Builder apply(ImmutableCleanupContext.Builder builder) {
+        return applicator.apply(builder, true);
+    }
+}

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
@@ -30,6 +30,6 @@ public class AWSResourcesSteps implements Closeable {
     public void close() throws IOException {
         resources.close();
         testContext.close();
-        LOGGER.info("Successfully removed externally created resourcess");
+        LOGGER.info("Successfully removed externally created resources");
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -72,8 +72,10 @@ public class FileSteps {
                             logFile, testContext.testResultsPath(), ie);
                 }
             });
-            // Remove the rest
-            platform.files().delete(testContext.installRoot());
+            if (!testContext.cleanupContext().persistInstalledSofware()) {
+                // Remove the rest
+                platform.files().delete(testContext.installRoot());
+            }
         }
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
@@ -68,7 +68,8 @@ public class GreengrassSteps implements Closeable {
     }
 
     @After(order = 99999)
-    public void close() {
+    public void close() throws IOException {
         stop();
+        greengrassContext.close();
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -5,7 +5,7 @@ import com.aws.greengrass.testing.api.model.ProxyConfig;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.RegistrationContext;
 import com.aws.greengrass.testing.model.TestContext;
-import com.aws.greengrass.testing.modules.AWSResourcesContext;
+import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.resources.iam.IamRoleSpec;
 import com.aws.greengrass.testing.resources.iot.IotLifecycle;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
@@ -1,5 +1,6 @@
 package com.aws.greengrass.testing.model;
 
+import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.TestingModel;
 import com.aws.greengrass.testing.api.util.FileUtils;
 import org.immutables.value.Value;
@@ -17,12 +18,16 @@ interface GreengrassContextModel extends Closeable {
 
     Path tempDirectory();
 
+    CleanupContext cleanupContext();
+
     default Path greengrassPath() {
         return tempDirectory().resolve("greengrass");
     }
 
     @Override
     default void close() throws IOException {
-        FileUtils.recursivelyDelete(tempDirectory());
+        if (!cleanupContext().persistGeneratedFiles()) {
+            FileUtils.recursivelyDelete(tempDirectory());
+        }
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
@@ -1,5 +1,6 @@
 package com.aws.greengrass.testing.model;
 
+import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.TestId;
 import com.aws.greengrass.testing.api.model.TestingModel;
 import com.aws.greengrass.testing.api.util.FileUtils;
@@ -17,6 +18,7 @@ interface TestContextModel extends Closeable {
     TestId testId();
     Path testDirectory();
     Path testResultsPath();
+    CleanupContext cleanupContext();
 
     @Value.Default
     default String logLevel() {
@@ -40,6 +42,8 @@ interface TestContextModel extends Closeable {
 
     @Override
     default void close() throws IOException {
-        FileUtils.recursivelyDelete(testDirectory());
+        if (!cleanupContext().persistGeneratedFiles()) {
+            FileUtils.recursivelyDelete(testDirectory());
+        }
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -1,5 +1,6 @@
 package com.aws.greengrass.testing.modules;
 
+import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -61,7 +62,9 @@ public class GreengrassContextModule extends AbstractModule {
 
     @Provides
     @Singleton
-    static GreengrassContext providesNucleusContext(@Named(JacksonModule.YAML) ObjectMapper mapper) {
+    static GreengrassContext providesNucleusContext(
+            @Named(JacksonModule.YAML) ObjectMapper mapper,
+            final CleanupContext cleanupContext) {
         try {
             final Path archivePath = Paths.get(Objects.requireNonNull(System.getProperty(NUCLEUS_ARCHIVE_PATH),
                     "Parameter " + NUCLEUS_ARCHIVE_PATH + " is required!"));
@@ -71,6 +74,7 @@ public class GreengrassContextModule extends AbstractModule {
                     .version(System.getProperty(NUCLEUS_VERSION, DEFAULT_NUCLEUS_VERSION))
                     .archivePath(archivePath)
                     .tempDirectory(tempDirectory)
+                    .cleanupContext(cleanupContext)
                     .build();
         } catch (NullPointerException | IOException ie) {
             throw new ModuleProvisionException(ie);

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassModule.java
@@ -3,6 +3,7 @@ package com.aws.greengrass.testing.modules;
 import com.aws.greengrass.testing.DefaultGreengrass;
 import com.aws.greengrass.testing.api.Greengrass;
 import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.platform.Platform;
 import com.google.auto.service.AutoService;
 import com.google.inject.AbstractModule;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -2,6 +2,7 @@ package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.ScenarioTestRuns;
 import com.aws.greengrass.testing.api.TestRuns;
+import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.TestId;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
@@ -46,7 +47,9 @@ public class TestContextModule extends AbstractModule {
 
     @Provides
     @ScenarioScoped
-    static TestContext providesTestContext(final TestId testId) {
+    static TestContext providesTestContext(
+            final TestId testId,
+            final CleanupContext cleanupContext) {
         Path testDirectory = Paths.get(testId.id());
         Path testResultsPath = Paths.get(System.getProperty(TEST_RESULTS_PATH, "testResults"));
         try {
@@ -59,6 +62,7 @@ public class TestContextModule extends AbstractModule {
                 .testId(testId)
                 .testResultsPath(testResultsPath)
                 .testDirectory(testDirectory)
+                .cleanupContext(cleanupContext)
                 .build();
     }
 }

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -1,6 +1,8 @@
 package com.aws.greengrass.testing.modules;
 
+import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.ProxyConfig;
+import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.google.auto.service.AutoService;
@@ -29,8 +31,8 @@ public class AWSResourcesModule extends AbstractModule {
 
     @Provides
     @ScenarioScoped
-    static AWSResources providesAWSResources(Set<AWSResourceLifecycle> lifecycles) {
-        return new AWSResources(lifecycles);
+    static AWSResources providesAWSResources(Set<AWSResourceLifecycle> lifecycles, CleanupContext cleanupContext) {
+        return new AWSResources(lifecycles, cleanupContext);
     }
 
     @Provides

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
@@ -1,4 +1,4 @@
-package com.aws.greengrass.testing.modules;
+package com.aws.greengrass.testing.modules.model;
 
 import com.aws.greengrass.testing.api.model.ProxyConfig;
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
@@ -12,5 +12,7 @@ public interface AWSResourceLifecycle<Client> extends Closeable {
 
     <U extends ResourceSpec<Client, R>, R extends AWSResource<Client>> Stream<U> trackingSpecs(Class<U> specClass);
 
+    void persist();
+
     void close() throws IOException;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allowing customers to leave generated things around for debugging purposes. This can grow into more of a serialization / deserialization mechanism to invoke existing test cases on existing contexts. Doing so must be done with care as dirty contexts can violate the spirit of scenario testing (and thusly, will not be implemented at the moment).

```
# will leave only the generated AWS resources
-Dgg.persist=aws.resources
# will leave the generated AWS resources and installed software running on the device
-Dgg.persist=aws.resources,installed.software
# will leave everything, even the temporarily generated files on disk to fulfill testing
-Dgg.persist=aws.resources.installed.software,generated.files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
