### PR TITLE
feat: Adding resource tagging scoped to test id.

### DIFF
--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -2,6 +2,7 @@ package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.ProxyConfig;
+import com.aws.greengrass.testing.api.model.TestId;
 import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
 import com.aws.greengrass.testing.resources.AWSResources;
@@ -31,8 +32,11 @@ public class AWSResourcesModule extends AbstractModule {
 
     @Provides
     @ScenarioScoped
-    static AWSResources providesAWSResources(Set<AWSResourceLifecycle> lifecycles, CleanupContext cleanupContext) {
-        return new AWSResources(lifecycles, cleanupContext);
+    static AWSResources providesAWSResources(
+            Set<AWSResourceLifecycle> lifecycles,
+            CleanupContext cleanupContext,
+            TestId testId) {
+        return new AWSResources(lifecycles, cleanupContext, testId);
     }
 
     @Provides

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceTagMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceTagMixin.java
@@ -1,0 +1,13 @@
+package com.aws.greengrass.testing.resources;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface ResourceTagMixin<T> {
+    T convertTag(Map.Entry<String, String> entry);
+
+    default Collection<T> convertTags(Map<String, String> tags) {
+        return tags.entrySet().stream().map(this::convertTag).collect(Collectors.toList());
+    }
+}

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentSpecModel.java
@@ -30,6 +30,7 @@ interface GreengrassComponentSpecModel extends ResourceSpec<GreengrassV2Client, 
         CreateComponentVersionResponse created = client.createComponentVersion(CreateComponentVersionRequest.builder()
                 .inlineRecipe(inlineRecipe())
                 .lambdaFunction(lambdaFunction())
+                .tags(resources.generateResourceTags())
                 .build());
         return GreengrassComponentSpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
@@ -78,6 +78,7 @@ interface GreengrassDeploymentSpecModel extends ResourceSpec<GreengrassV2Client,
                 .components(components())
                 .deploymentPolicies(deploymentPolicies())
                 .iotJobConfiguration(deploymentJobConfiguration())
+                .tags(resources.generateResourceTags())
                 .build());
         return GreengrassDeploymentSpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
-interface IamPolicySpecModel extends ResourceSpec<IamClient, IamPolicy> {
+interface IamPolicySpecModel extends ResourceSpec<IamClient, IamPolicy>, IamTaggingMixin {
     String policyName();
     String policyDocument();
 
@@ -21,6 +21,7 @@ interface IamPolicySpecModel extends ResourceSpec<IamClient, IamPolicy> {
         CreatePolicyResponse createdPolicy = client.createPolicy(CreatePolicyRequest.builder()
                 .policyDocument(policyDocument())
                 .policyName(policyName())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
         return IamPolicySpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
@@ -6,14 +6,16 @@ import com.aws.greengrass.testing.resources.ResourceSpec;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iam.IamClient;
-import software.amazon.awssdk.services.iam.model.*;
+import software.amazon.awssdk.services.iam.model.AttachRolePolicyRequest;
+import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
+import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
 
 import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
 @JsonDeserialize(builder = IamRoleSpec.Builder.class)
-interface IamRoleSpecModel extends ResourceSpec<IamClient, IamRole> {
+interface IamRoleSpecModel extends ResourceSpec<IamClient, IamRole>, IamTaggingMixin {
     @Nullable
     String policyArn();
     String roleName();
@@ -25,6 +27,7 @@ interface IamRoleSpecModel extends ResourceSpec<IamClient, IamRole> {
         CreateRoleResponse createdRole = client.createRole(CreateRoleRequest.builder()
                 .roleName(roleName())
                 .assumeRolePolicyDocument(trustDocument())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
 
         IamPolicySpec policySpec = resources.create(IamPolicySpec.builder()

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamTaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamTaggingMixin.java
@@ -1,0 +1,12 @@
+package com.aws.greengrass.testing.resources.iam;
+
+import com.aws.greengrass.testing.resources.ResourceTagMixin;
+import software.amazon.awssdk.services.iam.model.Tag;
+
+import java.util.Map;
+
+interface IamTaggingMixin extends ResourceTagMixin<Tag> {
+    default Tag convertTag(Map.Entry<String, String> tag) {
+        return Tag.builder().key(tag.getKey()).value(tag.getValue()).build();
+    }
+}

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
@@ -9,13 +9,14 @@ import software.amazon.awssdk.services.iot.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.iot.model.AttachThingPrincipalRequest;
 import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateRequest;
 import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateResponse;
+import software.amazon.awssdk.services.iot.model.TagResourceRequest;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
 
 @TestingModel
 @Value.Immutable
-interface IotCertificateSpecModel extends ResourceSpec<IotClient, IotCertificate> {
+interface IotCertificateSpecModel extends ResourceSpec<IotClient, IotCertificate>, IotTaggingMixin {
     @Value.Default
     default boolean active() {
         return true;
@@ -30,6 +31,11 @@ interface IotCertificateSpecModel extends ResourceSpec<IotClient, IotCertificate
     default IotCertificateSpec create(IotClient client, AWSResources resources) {
         CreateKeysAndCertificateResponse created = client.createKeysAndCertificate(CreateKeysAndCertificateRequest.builder()
                 .setAsActive(active())
+                .build());
+
+        client.tagResource(TagResourceRequest.builder()
+                .resourceArn(created.certificateArn())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
 
         client.attachThingPrincipal(AttachThingPrincipalRequest.builder()

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 @TestingModel
 @Value.Immutable
 @JsonDeserialize(builder = IotPolicySpec.Builder.class)
-interface IotPolicySpecModel extends ResourceSpec<IotClient, IotPolicy> {
+interface IotPolicySpecModel extends ResourceSpec<IotClient, IotPolicy>, IotTaggingMixin {
     String policyName();
     String policyDocument();
 
@@ -28,6 +28,7 @@ interface IotPolicySpecModel extends ResourceSpec<IotClient, IotPolicy> {
         CreatePolicyResponse response = client.createPolicy(CreatePolicyRequest.builder()
                 .policyDocument(policyDocument())
                 .policyName(policyName())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
         return IotPolicySpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
-interface IotRoleAliasSpecModel extends ResourceSpec<IotClient, IotRoleAlias> {
+interface IotRoleAliasSpecModel extends ResourceSpec<IotClient, IotRoleAlias>, IotTaggingMixin {
     String name();
     IamRole iamRole();
 
@@ -22,6 +22,7 @@ interface IotRoleAliasSpecModel extends ResourceSpec<IotClient, IotRoleAlias> {
         CreateRoleAliasResponse createdAlias = client.createRoleAlias(CreateRoleAliasRequest.builder()
                 .roleAlias(name())
                 .roleArn(iamRole().roleArn())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
         return IotRoleAliasSpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotTaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotTaggingMixin.java
@@ -1,0 +1,13 @@
+package com.aws.greengrass.testing.resources.iot;
+
+import com.aws.greengrass.testing.resources.ResourceTagMixin;
+import software.amazon.awssdk.services.iot.model.Tag;
+
+import java.util.Map;
+
+interface IotTaggingMixin extends ResourceTagMixin<Tag> {
+    @Override
+    default Tag convertTag(Map.Entry<String, String> tag) {
+        return Tag.builder().key(tag.getKey()).value(tag.getValue()).build();
+    }
+}

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
-interface IotThingGroupSpecModel extends ResourceSpec<IotClient, IotThingGroup> {
+interface IotThingGroupSpecModel extends ResourceSpec<IotClient, IotThingGroup>, IotTaggingMixin {
     String groupName();
     @Nullable
     String parentGroupName();
@@ -22,6 +22,7 @@ interface IotThingGroupSpecModel extends ResourceSpec<IotClient, IotThingGroup> 
         CreateThingGroupResponse createdGroup = client.createThingGroup(CreateThingGroupRequest.builder()
                 .parentGroupName(parentGroupName())
                 .thingGroupName(groupName())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
         return IotThingGroupSpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.iot.model.CreateThingRequest;
 import software.amazon.awssdk.services.iot.model.CreateThingResponse;
+import software.amazon.awssdk.services.iot.model.TagResourceRequest;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 
 @TestingModel
 @Value.Immutable
-interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing> {
+interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing>, IotTaggingMixin {
     @Nullable
     Set<IotThingGroupSpec> thingGroups();
 
@@ -37,6 +38,11 @@ interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing> {
 
         CreateThingResponse createdThing = client.createThing(CreateThingRequest.builder()
                 .thingName(thingName())
+                .build());
+
+        client.tagResource(TagResourceRequest.builder()
+                .resourceArn(createdThing.thingArn())
+                .tags(convertTags(resources.generateResourceTags()))
                 .build());
 
         IotRoleAliasSpec updatedRoleAlias = null;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketSpecModel.java
@@ -7,12 +7,14 @@ import org.immutables.value.Value;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.Tagging;
 
 import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
-interface S3BucketSpecModel extends ResourceSpec<S3Client, S3Bucket> {
+interface S3BucketSpecModel extends ResourceSpec<S3Client, S3Bucket>, S3TaggingMixin {
     String bucketName();
 
     @Nullable
@@ -23,6 +25,12 @@ interface S3BucketSpecModel extends ResourceSpec<S3Client, S3Bucket> {
     default S3BucketSpec create(S3Client client, AWSResources resources) {
         CreateBucketResponse response = client.createBucket(CreateBucketRequest.builder()
                 .bucket(bucketName())
+                .build());
+        client.putBucketTagging(PutBucketTaggingRequest.builder()
+                .bucket(bucketName())
+                .tagging(Tagging.builder()
+                        .tagSet(convertTags(resources.generateResourceTags()))
+                        .build())
                 .build());
         return S3BucketSpec.builder()
                 .from(this)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
@@ -8,12 +8,13 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.Tagging;
 
 import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
-interface S3ObjectSpecModel extends ResourceSpec<S3Client, S3Object> {
+interface S3ObjectSpecModel extends ResourceSpec<S3Client, S3Object>, S3TaggingMixin {
     String key();
     String bucket();
     RequestBody content();
@@ -27,6 +28,9 @@ interface S3ObjectSpecModel extends ResourceSpec<S3Client, S3Object> {
         final PutObjectRequest putRequest = PutObjectRequest.builder()
                 .bucket(bucket())
                 .key(key())
+                .tagging(Tagging.builder()
+                        .tagSet(convertTags(resources.generateResourceTags()))
+                        .build())
                 .build();
         final PutObjectResponse putResponse = client.putObject(putRequest, content());
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3TaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3TaggingMixin.java
@@ -1,0 +1,12 @@
+package com.aws.greengrass.testing.resources.s3;
+
+import com.aws.greengrass.testing.resources.ResourceTagMixin;
+import software.amazon.awssdk.services.s3.model.Tag;
+
+import java.util.Map;
+
+interface S3TaggingMixin extends ResourceTagMixin<Tag> {
+    default Tag convertTag(Map.Entry<String, String> tag) {
+        return Tag.builder().key(tag.getKey()).value(tag.getValue()).build();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding resource tagging to the created AWS resources for two reasons:

1. Adding resource tagging so customers can scope to least privileged ACL's
2. Customers can easily find and perform actions on resources through RAM

A new `ResourceTagMixin` is added to lay tag conversion specific to AWS resource. This behavior can be expanded to be more automatic in the `AWSResourceLifecyle` if a pattern emerges from more resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
