### PR TITLE
fix: Addressing some more file based remote platform bugs.

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -6,6 +6,7 @@ import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.RegistrationContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
+import com.aws.greengrass.testing.platform.Platform;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.resources.iam.IamRoleSpec;
 import com.aws.greengrass.testing.resources.iot.IotLifecycle;
@@ -43,10 +44,12 @@ public class RegistrationSteps {
     private final IamSteps iamSteps;
     private final IotSteps iotSteps;
     private final Device device;
+    private final Platform platform;
 
     @Inject
     public RegistrationSteps(
             Device device,
+            Platform platform,
             AWSResources resources,
             IamSteps iamSteps,
             IotSteps iotSteps,
@@ -55,6 +58,7 @@ public class RegistrationSteps {
             GreengrassContext greengrassContext,
             AWSResourcesContext resourcesContext) {
         this.device = device;
+        this.platform = platform;
         this.resources = resources;
         this.iamSteps = iamSteps;
         this.testContext = testContext;
@@ -143,6 +147,7 @@ public class RegistrationSteps {
         Files.write(testContext.testDirectory().resolve("rootCA.pem"), registrationContext.rootCA().getBytes(StandardCharsets.UTF_8));
         Files.write(configFilePath.resolve("config.yaml"), config.getBytes(StandardCharsets.UTF_8));
         // Copy to where the nucleus will read it
+        platform.files().makeDirectories(testContext.installRoot());
         device.copyTo(testContext.testDirectory(), testContext.installRoot());
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
@@ -42,6 +42,14 @@ public class DevicePredicatePlatformFiles implements PlatformFiles {
     }
 
     @Override
+    public void makeDirectories(Path filePath) throws CommandExecutionException {
+        delegate(files -> {
+            files.makeDirectories(filePath);
+            return null;
+        });
+    }
+
+    @Override
     public void delete(Path filePath) throws CommandExecutionException {
         delegate(files -> {
             files.delete(filePath);

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
@@ -34,6 +34,15 @@ public class LocalFiles implements PlatformFiles {
     }
 
     @Override
+    public void makeDirectories(Path filePath) throws CommandExecutionException {
+        try {
+            Files.createDirectories(filePath);
+        } catch (IOException e) {
+            throw new CommandExecutionException(e, CommandInput.of("makeDirectories: " + filePath));
+        }
+    }
+
+    @Override
     public List<Path> listContents(Path filePath) throws CommandExecutionException {
         if (Files.isRegularFile(filePath)) {
             return Arrays.asList(filePath);

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
@@ -18,6 +18,8 @@ public interface PlatformFiles {
 
     void delete(Path filePath) throws  CommandExecutionException;
 
+    void makeDirectories(Path filePath) throws CommandExecutionException;
+
     List<Path> listContents(Path filePath) throws CommandExecutionException;
 
     default void copyFrom(Path source, Path destination) throws CopyException, CommandExecutionException {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
@@ -28,6 +28,11 @@ public abstract class UnixFiles implements PlatformFiles {
     }
 
     @Override
+    public void makeDirectories(Path filePath) throws CommandExecutionException {
+        commands.execute(CommandInput.of("mkdir -p " + filePath.toString()));
+    }
+
+    @Override
     public List<Path> listContents(final Path filePath) throws CommandExecutionException {
         final String[] files = commands.executeToString(CommandInput.builder()
                 .line("find").addArgs(filePath.toString(), "-type", "f")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- If the `installRoot` was directories deep, the full path must exists
- This is temporarily added in the absence of IDT support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
