### PR TITLE
feat: Adding a timeout multiplier to all wait authorities.

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -6,6 +6,7 @@ import com.aws.greengrass.testing.api.device.exception.CommandExecutionException
 import com.aws.greengrass.testing.api.device.exception.CopyException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.device.model.PlatformOS;
+import com.aws.greengrass.testing.api.model.TimeoutMultiplier;
 import com.google.auto.service.AutoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,6 +31,16 @@ public class LocalDevice implements Device {
     private static final Logger LOGGER = LogManager.getLogger(LocalDevice.class);
     private static final String TYPE = "LOCAL";
     private static final int BUFFER = 100_000;
+    private final TimeoutMultiplier multiplier;
+
+    public LocalDevice(final TimeoutMultiplier multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    public LocalDevice() {
+        this(TimeoutMultiplier.builder().build());
+    }
+
 
     @Override
     public String id() {
@@ -54,7 +65,7 @@ public class LocalDevice implements Device {
             if (Objects.isNull(input.timeout())) {
                 process.waitFor();
             } else {
-                process.waitFor(input.timeout(), TimeUnit.SECONDS);
+                process.waitFor(multiplier.multiply(input.timeout()), TimeUnit.SECONDS);
             }
             final int exitCode = process.exitValue();
             if (exitCode != 0) {

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
@@ -1,0 +1,24 @@
+package com.aws.greengrass.testing.api.model;
+
+import org.immutables.value.Value;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+@TestingModel
+@Value.Immutable
+interface TimeoutMultiplierModel {
+    @Value.Default
+    default double multiplier() {
+        String value = System.getenv("TIMEOUT_MULTIPLIER");
+        if (Objects.nonNull(value)) {
+            return Double.parseDouble(value);
+        } else {
+            return 1.0;
+        }
+    }
+
+    default long multiply(@Nonnull Number value) {
+        return Math.round(multiplier() * value.doubleValue());
+    }
+}

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
@@ -1,21 +1,27 @@
 package com.aws.greengrass.testing.features;
 
+import com.aws.greengrass.testing.api.model.TimeoutMultiplier;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.When;
 
+import javax.inject.Inject;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @ScenarioScoped
 public class WaitSteps {
     private static final long DEFAULT_INTERVAL = 100L;
+    private final TimeoutMultiplier multiplier;
+
+    @Inject
+    public WaitSteps(TimeoutMultiplier multiplier) {
+        this.multiplier = multiplier;
+    }
 
     @When("I wait {int} {word}")
     public void until(int value, String unit) throws InterruptedException {
-        Thread.sleep(TimeUnit.valueOf(unit.toUpperCase()).toMillis(value));
+        Thread.sleep(TimeUnit.valueOf(unit.toUpperCase()).toMillis(multiplier.multiply(value)));
     }
 
     public <T> boolean untilTerminal(
@@ -36,7 +42,7 @@ public class WaitSteps {
                 break;
             }
             Thread.sleep(DEFAULT_INTERVAL);
-        } while (System.currentTimeMillis() - startTime < unit.toMillis(value));
+        } while (System.currentTimeMillis() - startTime < unit.toMillis(multiplier.multiply(value)));
         return result;
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
@@ -2,6 +2,7 @@ package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.api.device.local.LocalDevice;
+import com.aws.greengrass.testing.api.model.TimeoutMultiplier;
 import com.google.auto.service.AutoService;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
@@ -21,13 +22,13 @@ public class DeviceModule extends AbstractModule {
     @Provides
     @ScenarioScoped
     static Device providesDevice(Map<String, Device> devicePool) {
-        return devicePool.getOrDefault(System.getProperty(DEVICE_MODE, "LOCAL"), providesLocalDevice());
+        return devicePool.get(System.getProperty(DEVICE_MODE, "LOCAL"));
     }
 
     @Singleton
     @ProvidesIntoMap
     @StringMapKey("LOCAL")
-    static Device providesLocalDevice() {
-        return new LocalDevice();
+    static Device providesLocalDevice(TimeoutMultiplier multiplier) {
+        return new LocalDevice(multiplier);
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -4,6 +4,7 @@ import com.aws.greengrass.testing.ScenarioTestRuns;
 import com.aws.greengrass.testing.api.TestRuns;
 import com.aws.greengrass.testing.api.model.CleanupContext;
 import com.aws.greengrass.testing.api.model.TestId;
+import com.aws.greengrass.testing.api.model.TimeoutMultiplier;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
 import com.google.auto.service.AutoService;
@@ -35,6 +36,12 @@ public class TestContextModule extends AbstractModule {
     @Singleton
     static TestRuns providesTestRunTracker() {
         return new ScenarioTestRuns();
+    }
+
+    @Provides
+    @Singleton
+    static TimeoutMultiplier providesTimeoutMultiplier() {
+        return TimeoutMultiplier.builder().build();
     }
 
     @Provides


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Orchestration layers can magically multiply all waits throughout the framework
- `WaitSteps` and `LocalDevice` adhere to the wait. Thus, any device type will use the `TimeoutMultiplier` provided by the framework to adjust `execute` timeouts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
