### PR TITLE
chore: applying greengrass checkstyle throughout codebase

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
@@ -1,7 +1,6 @@
 package com.aws.greengrass.testing.api.device;
 
 
-
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
 import com.aws.greengrass.testing.api.device.exception.CopyException;
 import com.aws.greengrass.testing.api.device.local.LocalDevice;
@@ -35,14 +34,4 @@ public interface Device {
     }
 
     boolean exists(Path file);
-
-    static Device acquire(String type) {
-        return StreamSupport.stream(
-                Spliterators.spliteratorUnknownSize(
-                        ServiceLoader.load(Device.class).iterator(),
-                        Spliterator.DISTINCT), false)
-                .filter(device -> device.type().equals(type))
-                .findFirst()
-                .orElseGet(LocalDevice::new);
-    }
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CommandExecutionException.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CommandExecutionException.java
@@ -9,6 +9,13 @@ public class CommandExecutionException extends RuntimeException {
     private int exitCode;
     private final CommandInput input;
 
+    /**
+     * Creates a {@link CommandExecutionException}.
+     *
+     * @param message The underlying reason for the failure.
+     * @param exitCode The resulting exit code from the command.
+     * @param input The source input provided by the customer.
+     */
     public CommandExecutionException(String message, int exitCode, CommandInput input) {
         super(message);
         this.exitCode = exitCode;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CopyException.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CopyException.java
@@ -8,6 +8,13 @@ public class CopyException extends RuntimeException {
     private final Path source;
     private final Path destination;
 
+    /**
+     * Create a {@link CopyException} with a cause, the source, destination values.
+     *
+     * @param ex The underlying cause of the copy failure
+     * @param source The source {@link Path}. Does not need to be absolute.
+     * @param destination The destination {@link Path}. Usually absolute.
+     */
     public CopyException(Throwable ex, Path source, Path destination) {
         super(ex);
         this.destination = destination;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -19,7 +19,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -110,10 +109,7 @@ public class LocalDevice implements Device {
 
     @Override
     public PlatformOS platform() {
-        return PlatformOS.builder()
-                .name(System.getProperty("os.name"))
-                .arch(System.getProperty("os.arch"))
-                .build();
+        return PlatformOS.builder().name(System.getProperty("os.name")).arch(System.getProperty("os.arch")).build();
     }
 
     @Override

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/CommandInputModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/CommandInputModel.java
@@ -3,9 +3,9 @@ package com.aws.greengrass.testing.api.device.model;
 import com.aws.greengrass.testing.api.model.TestingModel;
 import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.List;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/PlatformOSModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/PlatformOSModel.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 interface PlatformOSModel {
     String name();
+
     String arch();
 
     default boolean isWindows() {

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
@@ -27,10 +27,15 @@ public abstract class CleanupContext {
         return ImmutableCleanupContext.builder();
     }
 
+    /**
+     * Create a concrete {@link CleanupContext} from a collection of {@link PersistMode}.
+     *
+     * @param modes User provided {@link PersistMode} to be used to bypass cleanup.
+     * @return
+     */
     public static CleanupContext fromModes(Collection<PersistMode> modes) {
         return modes.stream()
-                .reduce(CleanupContext.builder(),
-                        (builder, mode) -> mode.apply(builder),
-                        (left, right) -> left).build();
+                .reduce(CleanupContext.builder(), (builder, mode) -> mode.apply(builder), (left, right) -> left)
+                .build();
     }
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideNameVersionModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideNameVersionModel.java
@@ -6,5 +6,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 interface ComponentOverrideNameVersionModel {
     String name();
+
     ComponentOverrideVersion version();
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideVersionModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideVersionModel.java
@@ -6,5 +6,6 @@ import org.immutables.value.Value;
 @Value.Immutable
 interface ComponentOverrideVersionModel {
     String type();
+
     String value();
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverridesModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverridesModel.java
@@ -2,9 +2,9 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
@@ -15,9 +15,7 @@ interface ComponentOverridesModel {
     Map<String, ComponentOverrideVersion> overrides();
 
     default Optional<ComponentOverrideNameVersion> component(final String name) {
-        return Optional.ofNullable(overrides().get(name)).map(version -> ComponentOverrideNameVersion.builder()
-                .name(name)
-                .version(version)
-                .build());
+        return Optional.ofNullable(overrides().get(name))
+                .map(version -> ComponentOverrideNameVersion.builder().name(name).version(version).build());
     }
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
@@ -20,14 +20,20 @@ public enum PersistMode implements Function<ImmutableCleanupContext.Builder, Imm
         return name().toLowerCase().replace('_', '.');
     }
 
+    /**
+     * Pull a {@link PersistMode} from a string value like an input parameter from {@link System} getProperty.
+     *
+     * @param value String value to convert to {@link PersistMode}
+     * @return
+     */
     public static PersistMode fromConfig(String value) {
         for (PersistMode mode : values()) {
             if (mode.equals(PersistMode.valueOf(value.replace('.', '_').toUpperCase()))) {
                 return mode;
             }
         }
-        throw new IllegalArgumentException("Could not find a persist value mode for " + value
-                + ". Use any or all: " + Arrays.toString(values()));
+        throw new IllegalArgumentException(
+                "Could not find a persist value mode for " + value + ". Use any or all: " + Arrays.toString(values()));
     }
 
     @Override

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ProxyConfig.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ProxyConfig.java
@@ -2,21 +2,26 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, visibility = Value.Style.ImplementationVisibility.PACKAGE)
 public abstract class ProxyConfig {
     public abstract String scheme();
+
     public abstract String host();
+
     public abstract String proxyUrl();
+
     @Nullable
     public abstract Integer port();
+
     @Nullable
     public abstract String username();
+
     @Nullable
     public abstract String password();
 
@@ -28,9 +33,16 @@ public abstract class ProxyConfig {
         return ImmutableProxyConfig.builder();
     }
 
+    /**
+     * Create a concrete {@link ProxyConfig} from a fully qualified URL string.
+     *
+     * @param url Full URL for proxy configuration to be used in all subsequent clients.
+     * @return
+     */
     public static ProxyConfig fromURL(String url) {
         Integer port = null;
-        String username = null, password = null;
+        String username = null;
+        String password = null;
         URI uri = URI.create(url);
         if (uri.getPort() != 0) {
             port = uri.getPort();
@@ -42,13 +54,7 @@ public abstract class ProxyConfig {
                 password = parts[1];
             }
         }
-        return ProxyConfig.builder()
-                .scheme(uri.getScheme())
-                .host(uri.getHost())
-                .port(port)
-                .proxyUrl(url)
-                .username(username)
-                .password(password)
-                .build();
+        return ProxyConfig.builder().scheme(uri.getScheme()).host(uri.getHost()).port(port).proxyUrl(url)
+                .username(username).password(password).build();
     }
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestIdModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestIdModel.java
@@ -2,12 +2,27 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
+import java.util.StringJoiner;
+
 @TestingModel
 @Value.Immutable
 interface TestIdModel {
+    @Value.Default
+    default String prefix() {
+        return "";
+    }
+
     String id();
 
+    default String prefixedId() {
+        StringJoiner joiner = new StringJoiner("-");
+        if (!prefix().isEmpty()) {
+            joiner.add(prefix());
+        }
+        return joiner.add(id()).toString();
+    }
+
     default String idFor(String type) {
-        return String.format("%s-%s", id(), type);
+        return String.format("%s-%s", prefixedId(), type);
     }
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
@@ -2,8 +2,8 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
-import javax.annotation.Nullable;
 import java.time.Duration;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestingModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestingModel.java
@@ -2,13 +2,7 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
-@Value.Style(
-        jdkOnly = true,
-        typeImmutable = "*",
-        typeModifiable = "*",
-        typeAbstract = "*Model",
-        allMandatoryParameters = true,
-        visibility = Value.Style.ImplementationVisibility.PUBLIC
-)
+@Value.Style(jdkOnly = true, typeImmutable = "*", typeModifiable = "*", typeAbstract = "*Model",
+        allMandatoryParameters = true, visibility = Value.Style.ImplementationVisibility.PUBLIC)
 public @interface TestingModel {
 }

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
@@ -2,8 +2,8 @@ package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 @TestingModel
 @Value.Immutable

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/util/FileUtils.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/util/FileUtils.java
@@ -11,6 +11,13 @@ public final class FileUtils {
     private FileUtils() {
     }
 
+    /**
+     * Recursively delete a file directory by path.
+     * <strong>Note</strong>: This strictly pertains to deleting directories on the host agent.
+     *
+     * @param directory Directory to delete completely
+     * @throws IOException Propagated IOException from surrounding nio utility methods
+     */
     public static void recursivelyDelete(Path directory) throws IOException {
         if (Files.exists(directory)) {
             try (Stream<Path> files = Files.walk(directory)) {

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/IPCModule.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/IPCModule.java
@@ -11,10 +11,10 @@ import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
 import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnectionConfig;
 import software.amazon.awssdk.eventstreamrpc.GreengrassConnectMessageSupplier;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 @Module
 public class IPCModule {

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Paddle.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Paddle.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 
 abstract class Paddle {
     private static final int TIMEOUT = 5;
+    
     enum Type {
         Ping, Pong;
     }
@@ -49,9 +50,9 @@ abstract class Paddle {
     }
 
     public void watch() throws InterruptedException, ExecutionException, TimeoutException {
-        SubscribeToTopicRequest subscribeToTopicRequest = new SubscribeToTopicRequest();
-        subscribeToTopicRequest.setTopic("say/" + type.name().toLowerCase());
-        ipc.subscribeToTopic(subscribeToTopicRequest, Optional.of(new StreamResponseHandler<SubscriptionResponseMessage>() {
+        SubscribeToTopicRequest subscribeRequest = new SubscribeToTopicRequest();
+        subscribeRequest.setTopic("say/" + type.name().toLowerCase());
+        ipc.subscribeToTopic(subscribeRequest, Optional.of(new StreamResponseHandler<SubscriptionResponseMessage>() {
             @Override
             public void onStreamEvent(SubscriptionResponseMessage subscriptionResponseMessage) {
                 String payload = new String(subscriptionResponseMessage.getBinaryMessage().getMessage(),

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PaddleComponent.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PaddleComponent.java
@@ -1,7 +1,6 @@
 package com.aws.greengrass.testing.examples.component;
 
 import dagger.Component;
-import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
 
 import javax.inject.Singleton;
 
@@ -9,5 +8,6 @@ import javax.inject.Singleton;
 @Singleton
 public interface PaddleComponent {
     Pong pong();
+
     Ping ping();
 }

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleSteps.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleSteps.java
@@ -28,11 +28,16 @@ public class ExampleSteps implements Closeable {
     private Path testFile;
 
     @Inject
-    public ExampleSteps(final TestId testId, final Path testDirectory) {
+    ExampleSteps(final TestId testId, final Path testDirectory) {
         this.testId = testId;
         this.testDirectory = testDirectory;
     }
 
+    /**
+     * Prepares scenario for testing.
+     *
+     * @throws IOException fails to prepare the scenario
+     */
     @Given("I have created the test directory")
     public void createTestDirectory() throws IOException {
         assertFalse(Files.exists(testDirectory));
@@ -46,6 +51,11 @@ public class ExampleSteps implements Closeable {
         Files.write(testFile, (FILE_CONTENTS + testId.idFor("contents")).getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Validate that a test file is created.
+     *
+     * @throws IOException fails to validate file
+     */
     @Then("the file is created with test information")
     public void validateTestFile() throws IOException {
         assertNotNull(testFile, "Create the file with 'I create a test file...'");

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
@@ -19,6 +19,14 @@ public class DefaultGreengrass implements Greengrass {
     private int greengrassProcess;
     private final TestContext testContext;
 
+    /**
+     * Creates a {@link Greengrass} software instance.
+     *
+     * @param platform Abstract {@link Platform}
+     * @param envStage String environment
+     * @param region AWS region name
+     * @param testContext The underlying {@link TestContext}
+     */
     public DefaultGreengrass(
             final Platform platform,
             String envStage,
@@ -28,6 +36,10 @@ public class DefaultGreengrass implements Greengrass {
         this.envStage = envStage;
         this.region = region;
         this.testContext = testContext;
+    }
+
+    private boolean isRunning() {
+        return greengrassProcess != 0;
     }
 
     @Override
@@ -59,12 +71,8 @@ public class DefaultGreengrass implements Greengrass {
         LOGGER.info("Starting Greengrass on pid {}", greengrassProcess);
     }
 
-    private boolean isRunning() {
-        return greengrassProcess != 0;
-    }
-
     @Override
-    synchronized public void stop() {
+    public synchronized void stop() {
         try {
             if (testContext.cleanupContext().persistInstalledSofware()) {
                 LOGGER.info("Leaving Greengrass running on pid: {}", greengrassProcess);

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
@@ -20,7 +20,7 @@ public class ScenarioTestRuns implements TestRuns {
     }
 
     @Override
-    synchronized public void track(TestRun run) {
+    public synchronized void track(TestRun run) {
         scenarios.add(run);
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
@@ -4,6 +4,7 @@ import com.aws.greengrass.testing.api.ComponentPreparationService;
 import com.aws.greengrass.testing.api.model.ComponentOverrideNameVersion;
 import com.aws.greengrass.testing.api.model.ComponentOverrideVersion;
 import com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle;
+import com.vdurmont.semver4j.Semver;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.greengrassv2.model.Component;
@@ -11,10 +12,8 @@ import software.amazon.awssdk.services.greengrassv2.model.ComponentLatestVersion
 import software.amazon.awssdk.services.greengrassv2.model.ComponentVersionListItem;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentVisibilityScope;
 
-import com.vdurmont.semver4j.Semver;
-
-import javax.inject.Inject;
 import java.util.Optional;
+import javax.inject.Inject;
 
 public class CloudComponentPreparationService implements ComponentPreparationService {
     private static final String LATEST = "LATEST";

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CompositeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CompositeComponentPreparationService.java
@@ -3,9 +3,9 @@ package com.aws.greengrass.testing.component;
 import com.aws.greengrass.testing.api.ComponentPreparationService;
 import com.aws.greengrass.testing.api.model.ComponentOverrideNameVersion;
 
-import javax.inject.Inject;
 import java.util.Map;
 import java.util.Optional;
+import javax.inject.Inject;
 
 public class CompositeComponentPreparationService implements ComponentPreparationService {
     private final Map<String, ComponentPreparationService> services;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
@@ -7,10 +7,10 @@ import com.aws.greengrass.testing.modules.JacksonModule;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 public class FileComponentPreparationService extends RecipeComponentPreparationService {
     @Inject

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
@@ -48,7 +48,7 @@ public class RecipeComponentPreparationService implements ComponentPreparationSe
         InputStream load(String version) throws IOException;
     }
 
-    public RecipeComponentPreparationService(
+    RecipeComponentPreparationService(
             ContentLoader loader,
             AWSResources resources,
             ObjectMapper mapper,

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
@@ -18,7 +18,7 @@ public class AWSResourcesSteps implements Closeable {
     private final TestContext testContext;
 
     @Inject
-    public AWSResourcesSteps(
+    AWSResourcesSteps(
             final AWSResources resources,
             final TestContext testContext) {
         this.resources = resources;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -10,11 +10,11 @@ import io.cucumber.java.en.Then;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +29,7 @@ public class FileSteps {
     private final WaitSteps waits;
 
     @Inject
-    public FileSteps(
+    FileSteps(
             Device device,
             Platform platform,
             TestContext testContext,
@@ -51,6 +51,15 @@ public class FileSteps {
         containsTimeout(file, contents, DEFAULT_TIMEOUT, TimeUnit.SECONDS.name());
     }
 
+    /**
+     * File contains content after a duration.
+     *
+     * @param file file on a {@link Device}
+     * @param contents file contents
+     * @param value integer value for a duration
+     * @param unit {@link TimeUnit} duration
+     * @throws InterruptedException thread was interrupted while waiting
+     */
     @Then("the file {word} on device contains {string} within {int} {word}")
     public void containsTimeout(String file, String contents, int value, String unit) throws InterruptedException {
         checkFileExists(file);
@@ -71,6 +80,11 @@ public class FileSteps {
                 .contains(line), component + " log contains '" + line + "'");
     }
 
+    /**
+     * Copy logs for the {@link Scenario} from the {@link Device} to the host.
+     *
+     * @param scenario the unique {@link Scenario}
+     */
     @After(order = 99899)
     public void copyLogs(final Scenario scenario) {
         Path logFolder = testContext.installRoot().resolve("logs");

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
@@ -10,9 +10,9 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
-import javax.inject.Inject;
 import java.io.Closeable;
 import java.io.IOException;
+import javax.inject.Inject;
 
 @ScenarioScoped
 public class GreengrassSteps implements Closeable {
@@ -23,7 +23,7 @@ public class GreengrassSteps implements Closeable {
     private final FileSteps files;
 
     @Inject
-    public GreengrassSteps(
+    GreengrassSteps(
             final Device device,
             final Greengrass greengrass,
             final GreengrassContext greengrassContext,
@@ -36,6 +36,9 @@ public class GreengrassSteps implements Closeable {
         this.files = files;
     }
 
+    /**
+     * Installs {@link Greengrass} for testing.
+     */
     @When("I install Greengrass")
     public void install() {
         device.copyTo(greengrassContext.greengrassPath(), testContext.installRoot().resolve("greengrass"));
@@ -43,9 +46,14 @@ public class GreengrassSteps implements Closeable {
         files.checkFileExists("logs/greengrass.log");
     }
 
+    /**
+     * Starts a {@link Greengrass} software instance.
+     *
+     * @throws InterruptedException Thread is interrupted while waiting for {@link Greengrass} to start
+     */
     @Given("my device is running Greengrass")
     @When("I start Greengrass")
-    public void start() throws IOException, InterruptedException {
+    public void start() throws InterruptedException {
         install();
         greengrass.start();
         launchedSuccessfully();

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
@@ -7,13 +7,11 @@ import com.aws.greengrass.testing.resources.iam.IamRoleSpec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.When;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 @ScenarioScoped
 public class IamSteps {
@@ -23,7 +21,7 @@ public class IamSteps {
     private final TestId testId;
 
     @Inject
-    public IamSteps(
+    IamSteps(
             TestId testId,
             @Named(JacksonModule.YAML) ObjectMapper mapper,
             AWSResources resources) {
@@ -32,6 +30,12 @@ public class IamSteps {
         this.testId = testId;
     }
 
+    /**
+     * Create a default IAM role to get a working {@link com.aws.greengrass.testing.api.Greengrass} instance.
+     *
+     * @return IamRoleSpec
+     * @throws RuntimeException failed to a default IAM policy
+     */
     @Given("I create a default IAM role for Greengrass")
     public IamRoleSpec createDefaultIamRole() {
         try {
@@ -41,6 +45,13 @@ public class IamSteps {
         }
     }
 
+    /**
+     * Create an IAM role from a configuration file.
+     *
+     * @param roleFile configuration file to create an IAM role from
+     * @return IamRoleSpec
+     * @throws IOException failed to read configuration from a file
+     */
     @Given("I create an IAM role from {word}")
     public IamRoleSpec createIamRole(String roleFile) throws IOException {
         try (InputStream in = getClass().getResourceAsStream(roleFile)) {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
@@ -8,11 +8,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Given;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
 
 @ScenarioScoped
 public class IotSteps {
@@ -22,7 +22,7 @@ public class IotSteps {
     private final TestId testId;
 
     @Inject
-    public IotSteps(
+    IotSteps(
             final TestId testId,
             final AWSResources resources,
             @Named(JacksonModule.YAML) final ObjectMapper mapper) {
@@ -36,11 +36,13 @@ public class IotSteps {
         return createDefaultPolicy(null);
     }
 
-    @Given("I create an IoT policy from {word}")
-    public IotPolicySpec createPolicy(String config) throws IOException {
-        return createPolicy(config, null);
-    }
-
+    /**
+     * Create the default IoT policy with a name override.
+     *
+     * @param policyNameOverride name to use for IoT policy
+     * @return IotPolicySpec
+     * @throws RuntimeException failed to create an IoT policy for some reason
+     */
     public IotPolicySpec createDefaultPolicy(String policyNameOverride) {
         try {
             return createPolicy(DEFAULT_POLICY_CONFIG, policyNameOverride);
@@ -49,6 +51,26 @@ public class IotSteps {
         }
     }
 
+    /**
+     * Create a new IoT policy using a configuration name.
+     *
+     * @param config name of the configuration for the policy
+     * @return IotPolicySpec
+     * @throws IOException failed to create a policy from configuration
+     */
+    @Given("I create an IoT policy from {word}")
+    public IotPolicySpec createPolicy(String config) throws IOException {
+        return createPolicy(config, null);
+    }
+
+    /**
+     * Create an IoT policy with a configuration and name override.
+     *
+     * @param config name of the config
+     * @param policyNameOverride override of the policy name
+     * @return IotPolicySpec
+     * @throws IOException failed to create a configuration
+     */
     public IotPolicySpec createPolicy(String config, String policyNameOverride) throws IOException {
         try (InputStream in = getClass().getResourceAsStream(config)) {
             IotPolicySpec spec = mapper.readValue(in, IotPolicySpec.class);

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
@@ -9,9 +9,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
-import javax.inject.Inject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.inject.Inject;
 
 @ScenarioScoped
 public class LoggerSteps {
@@ -20,10 +20,15 @@ public class LoggerSteps {
     private final TestContext testContext;
 
     @Inject
-    public LoggerSteps(final TestContext testContext) {
+    LoggerSteps(final TestContext testContext) {
         this.testContext = testContext;
     }
 
+    /**
+     * Setup the logging context for the thread local context.
+     *
+     * @param scenario unique {@link Scenario}
+     */
     @Before
     public void addContext(final Scenario scenario) {
         final Matcher matcher = FEATURE.matcher(scenario.getId());
@@ -32,7 +37,7 @@ public class LoggerSteps {
         if (matcher.find()) {
             feature = matcher.group(1);
         }
-        ThreadContext.put("testId", testContext.testId().id());
+        ThreadContext.put("testId", testContext.testId().prefixedId());
         ThreadContext.put("feature", feature);
         ThreadContext.put("scenarioId", scenario.getName());
         LOGGER.info("Attaching thread context to scenario: '{}'", scenario.getName());

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.utils.IoUtils;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import javax.inject.Inject;
 
 @ScenarioScoped
 public class RegistrationSteps {
@@ -47,7 +47,7 @@ public class RegistrationSteps {
     private final Platform platform;
 
     @Inject
-    public RegistrationSteps(
+    RegistrationSteps(
             Device device,
             Platform platform,
             AWSResources resources,
@@ -137,14 +137,16 @@ public class RegistrationSteps {
             additionalUpdatableFields.putIfAbsent("{role_alias}", "null");
         }
 
-        config = config.replace("{proxy_url}", resourcesContext.proxyConfig().map(ProxyConfig::proxyUrl).orElse(""));
+        config = config.replace("{proxy_url}",
+                resourcesContext.proxyConfig().map(ProxyConfig::proxyUrl).orElse(""));
         config = config.replace("{aws_region}", resourcesContext.region().metadata().id());
         config = config.replace("{nucleus_version}", greengrassContext.version());
         config = config.replace("{env_stage}", resourcesContext.envStage());
         config = config.replace("{posix_user}", testContext.currentUser());
         config = config.replace("{data_plane_port}", Integer.toString(registrationContext.connectionPort()));
 
-        Files.write(testContext.testDirectory().resolve("rootCA.pem"), registrationContext.rootCA().getBytes(StandardCharsets.UTF_8));
+        Files.write(testContext.testDirectory().resolve("rootCA.pem"),
+                registrationContext.rootCA().getBytes(StandardCharsets.UTF_8));
         Files.write(configFilePath.resolve("config.yaml"), config.getBytes(StandardCharsets.UTF_8));
         // Copy to where the nucleus will read it
         platform.files().makeDirectories(testContext.installRoot().getParent());

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
@@ -14,7 +14,7 @@ public class S3Steps {
     private final TestId testId;
 
     @Inject
-    public S3Steps(
+    S3Steps(
             final AWSResources resources,
             final TestId testId) {
         this.resources = resources;
@@ -26,6 +26,11 @@ public class S3Steps {
         createS3Bucket("gg-component-store");
     }
 
+    /**
+     * Create an S3 bucket based on a name.
+     *
+     * @param bucketName Name of the S3 bucket
+     */
     @When("I create an S3 bucket named {word}")
     public void createS3Bucket(String bucketName) {
         resources.create(S3BucketSpec.builder()

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
@@ -7,8 +7,8 @@ import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 
-import javax.inject.Inject;
 import java.time.Duration;
+import javax.inject.Inject;
 
 @ScenarioScoped
 public class ScenarioTrackerSteps {
@@ -16,7 +16,7 @@ public class ScenarioTrackerSteps {
     private long startTime;
 
     @Inject
-    public ScenarioTrackerSteps(final TestRuns scenarios) {
+    ScenarioTrackerSteps(final TestRuns scenarios) {
         this.scenarios = scenarios;
     }
 
@@ -25,6 +25,11 @@ public class ScenarioTrackerSteps {
         this.startTime = System.currentTimeMillis();
     }
 
+    /**
+     * Stop tracking a complete {@link Scenario}.
+     *
+     * @param scenario unique {@link Scenario}
+     */
     @After
     public void stop(Scenario scenario) {
         long duration = System.currentTimeMillis() - startTime;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
@@ -4,10 +4,10 @@ import com.aws.greengrass.testing.api.model.TimeoutMultiplier;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.When;
 
-import javax.inject.Inject;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import javax.inject.Inject;
 
 @ScenarioScoped
 public class WaitSteps {
@@ -15,7 +15,7 @@ public class WaitSteps {
     private final TimeoutMultiplier multiplier;
 
     @Inject
-    public WaitSteps(TimeoutMultiplier multiplier) {
+    WaitSteps(TimeoutMultiplier multiplier) {
         this.multiplier = multiplier;
     }
 
@@ -33,6 +33,15 @@ public class WaitSteps {
          return result && isValid.test(obtain.get());
     }
 
+    /**
+     * Wait until the evaluated predicate is true for a time.
+     *
+     * @param evaluate {@link Predicate} to evaluate
+     * @param value integer for a duration
+     * @param unit {@link TimeUnit} duration
+     * @return boolean
+     * @throws InterruptedException thread interrupted while waiting
+     */
     public boolean untilTrue(Supplier<Boolean> evaluate, int value, TimeUnit unit) throws InterruptedException {
         boolean result = false;
         long startTime = System.currentTimeMillis();

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
@@ -16,8 +16,11 @@ import java.util.Objects;
 @Value.Immutable
 interface TestContextModel extends Closeable {
     TestId testId();
+
     Path testDirectory();
+
     Path testResultsPath();
+
     CleanupContext cleanupContext();
 
     @Value.Default

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/ComponentPreparationModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/ComponentPreparationModule.java
@@ -5,7 +5,6 @@ import com.aws.greengrass.testing.component.ClasspathComponentPreparationService
 import com.aws.greengrass.testing.component.CloudComponentPreparationService;
 import com.aws.greengrass.testing.component.CompositeComponentPreparationService;
 import com.aws.greengrass.testing.component.FileComponentPreparationService;
-import com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle;
 import com.google.auto.service.AutoService;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
@@ -12,7 +12,6 @@ import com.google.inject.multibindings.ProvidesIntoMap;
 import com.google.inject.multibindings.StringMapKey;
 import io.cucumber.guice.ScenarioScoped;
 
-import javax.inject.Named;
 import java.util.Map;
 
 @AutoService(Module.class)

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.utils.IoUtils;
 
-import javax.inject.Named;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -24,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import javax.inject.Named;
 
 @AutoService(Module.class)
 public class GreengrassContextModule extends AbstractModule {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/RegistrationContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/RegistrationContextModule.java
@@ -8,7 +8,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 
-import javax.inject.Singleton;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +16,7 @@ import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import javax.inject.Singleton;
 
 @AutoService(Module.class)
 public class RegistrationContextModule extends AbstractModule {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -13,17 +13,18 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import io.cucumber.guice.ScenarioScoped;
 
-import javax.inject.Singleton;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
+import javax.inject.Singleton;
 
 @AutoService(Module.class)
 public class TestContextModule extends AbstractModule {
     private static final String TEST_RESULTS_PATH = "test.log.path";
+    private static final String TEST_ID_PREFIX = "test.id.prefix";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     static String randomString(int size) {
@@ -48,7 +49,8 @@ public class TestContextModule extends AbstractModule {
     @ScenarioScoped
     static TestId providesTestId() {
         return TestId.builder()
-                .id(randomString(20))
+                .prefix(System.getProperty(TEST_ID_PREFIX, ""))
+                .id(randomString(20)) // This should probably be replaced too
                 .build();
     }
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
@@ -6,12 +6,12 @@ import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 
-import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,10 +20,15 @@ public class DockerSteps {
     private final Platform platform;
 
     @Inject
-    public DockerSteps(final Platform platform) {
+    DockerSteps(final Platform platform) {
         this.platform = platform;
     }
 
+    /**
+     * Checks that the docker image does <strong>not</strong> exist on the {@link Platform} for this device.
+     *
+     * @param image fully qualified image name in <code>name:tag</code> representation
+     */
     @Given("the docker image {word} does not exist on the device")
     public void checkDockerImageIsMissing(String image) {
         Predicate<Set<String>> predicate = Set::isEmpty;

--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
@@ -20,6 +20,12 @@ public final class TestLauncher {
     private static final String DEFAULT_GLUE_PATH = "com.aws.greengrass";
     private static final String DEFAULT_FEATURES = "greengrass/features";
 
+    /**
+     * Start the {@link TestLauncher} wrapping a JUnit platform engine.
+     *
+     * @param args optional additional arguments for the runner
+     * @throws Exception any runtime failure before JUnit platform engine begins
+     */
     public static void main(String[] args) throws Exception {
         final Path output;
         if (args.length > 0) {
@@ -27,23 +33,25 @@ public final class TestLauncher {
         } else {
             output = Paths.get("");
         }
-        String tags = System.getProperty("tags");
         CommandLineOptions options = new CommandLineOptions();
         options.setTheme(Theme.UNICODE);
         options.setDetails(Details.TREE);
         options.setIncludedEngines(Arrays.asList(ENGINE));
+        String tags = System.getProperty("tags");
         if (Objects.nonNull(tags)) {
             options.setIncludedTagExpressions(Arrays.asList(tags));
         }
         options.setSelectedClasspathResources(Arrays.asList(System.getProperty("feature.path", DEFAULT_FEATURES)));
         final Path resultsXml = output.toAbsolutePath().resolve("TEST-greengrass-results.xml");
-        options.setConfigurationParameters(new HashMap<String, String>() {{
-           put("cucumber.glue", System.getProperty("glue.package", DEFAULT_GLUE_PATH));
-           put("cucumber.plugin", new StringJoiner(",")
-                   .add(StepTrackingReporting.class.getName())
-                   .add("junit:" + resultsXml.toString())
-                   .toString());
-        }});
+        options.setConfigurationParameters(new HashMap<String, String>() {
+            {
+                put("cucumber.glue", System.getProperty("glue.package", DEFAULT_GLUE_PATH));
+                put("cucumber.plugin", new StringJoiner(",")
+                        .add(StepTrackingReporting.class.getName())
+                        .add("junit:" + resultsXml.toString())
+                        .toString());
+            }
+        });
         final ConsoleTestExecutor executor = new ConsoleTestExecutor(options);
         final TestExecutionSummary summary = executor.execute(new PrintWriter(System.out));
         if (summary.getTestsFailedCount() > 0) {

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesCleanupModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesCleanupModule.java
@@ -14,7 +14,6 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.inject.Singleton;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
@@ -22,6 +21,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.inject.Singleton;
 
 @AutoService(Module.class)
 public class AWSResourcesCleanupModule extends AbstractModule {
@@ -85,9 +85,7 @@ public class AWSResourcesCleanupModule extends AbstractModule {
     @Provides
     @Singleton
     static CleanupContext providesCleanUpContext() {
-        /**
-         * TODO: switch to SPI so modules can specify their own persistence type and provider
-         */
+        // TODO: switch to SPI so modules can specify their own persistence type and provider
         final Set<PersistMode> modes = Optional.ofNullable(System.getProperty(PERSIST_TESTING_RESOURCES))
                 .map(resources -> resources.split("\\s*,\\s*"))
                 .map(Arrays::stream)

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -18,12 +18,12 @@ import software.amazon.awssdk.http.apache.ProxyConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
-import javax.inject.Singleton;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Singleton;
 
 @AutoService(Module.class)
 public class AWSResourcesModule extends AbstractModule {

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/ComponentOverridesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/ComponentOverridesModule.java
@@ -7,8 +7,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 
-import javax.inject.Singleton;
 import java.util.Optional;
+import javax.inject.Singleton;
 
 @AutoService(Module.class)
 public class ComponentOverridesModule extends AbstractModule {
@@ -22,12 +22,14 @@ public class ComponentOverridesModule extends AbstractModule {
         ComponentOverrides.Builder builder = ComponentOverrides.builder()
                 .bucketName(System.getProperty(COMPONENT_BUCKET));
         Optional.ofNullable(System.getProperty(COMPONENT_OVERRIDES)).ifPresent(overrideString -> {
-            // -Dgg.component.overrides=aws.greengrass.Nucleus:cloud:LATEST,aws.greengrass.LocalDebugConsole:file:/path/to/recipe.yml
+            // -Dgg.component.overrides=aws.greengrass.Nucleus:cloud:LATEST,
+            // aws.greengrass.LocalDebugConsole:file:/path/to/recipe.yml
             final String[] components = overrideString.split("\\s*,\\s*");
             for (String component : components) {
                 final String[] nameVersionParts = component.split(":", MAX_SPLIT_LIMIT);
                 final String[] versionParts = nameVersionParts[1].split(":", MAX_SPLIT_LIMIT);
-                String type, version;
+                String type;
+                String version;
                 if (versionParts.length == MAX_SPLIT_LIMIT) {
                     type = versionParts[0];
                     version = versionParts[1];

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 @Value.Immutable
 interface AWSResourcesContextModel {
     String envStage();
+
     Optional<ProxyConfig> proxyConfig();
+
     Region region();
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
@@ -17,6 +17,14 @@ public class DevicePredicatePlatformFiles implements PlatformFiles {
     private final PlatformFiles right;
     private final Predicate<Device> isLeft;
 
+    /**
+     * An "or" based predicate to delegate {@link PlatformFiles} implementations upon.
+     *
+     * @param isLeft A {@link Predicate} to switch which {@link PlatformFiles} implementation
+     * @param device An underlying {@link Device} entity to test
+     * @param left A {@link PlatformFiles} implementation to use if isLeft is true
+     * @param right A {@link PlatformFiles} implementation to use isLeft is false
+     */
     public DevicePredicatePlatformFiles(
             final Predicate<Device> isLeft,
             final Device device,

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
@@ -4,7 +4,6 @@ import com.aws.greengrass.testing.api.device.exception.CommandExecutionException
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.util.FileUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
@@ -22,6 +22,14 @@ public interface PlatformFiles {
 
     List<Path> listContents(Path filePath) throws CommandExecutionException;
 
+    /**
+     * Perform a recursive copy from remote source to local destination.
+     *
+     * @param source Remote {@link Path} to copy from the device
+     * @param destination Local {@link Path} to copy to the host
+     * @throws CopyException Any propagated local nio utility IOException
+     * @throws CommandExecutionException Any remote execution failing as a command exception
+     */
     default void copyFrom(Path source, Path destination) throws CopyException, CommandExecutionException {
         final Path destinationRoot = destination.resolve(source.getFileName());
         try {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
@@ -1,8 +1,8 @@
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.Device;
-import com.aws.greengrass.testing.platform.exception.PlatformResolutionException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
+import com.aws.greengrass.testing.platform.exception.PlatformResolutionException;
 import com.aws.greengrass.testing.platform.linux.LinuxPlatform;
 import com.aws.greengrass.testing.platform.macos.MacosPlatform;
 import com.aws.greengrass.testing.platform.windows.WindowsPlatform;
@@ -26,6 +26,11 @@ public class PlatformResolver {
         this.device = device;
     }
 
+    /**
+     * Resolve to a concrete {@link Platform} from the underlysing {@link Device} object.
+     *
+     * @return
+     */
     public Platform resolve() {
         final Map<String, Integer> ranks = createRanks();
         if (ranks.containsKey("linux")) {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxCommands.java
@@ -1,9 +1,6 @@
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.api.device.Device;
-import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
-import com.aws.greengrass.testing.api.device.model.CommandInput;
-import com.aws.greengrass.testing.platform.Commands;
 import com.aws.greengrass.testing.platform.UnixCommands;
 
 public class LinuxCommands extends UnixCommands {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosCommands.java
@@ -1,9 +1,6 @@
 package com.aws.greengrass.testing.platform.macos;
 
 import com.aws.greengrass.testing.api.device.Device;
-import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
-import com.aws.greengrass.testing.api.device.model.CommandInput;
-import com.aws.greengrass.testing.platform.Commands;
 import com.aws.greengrass.testing.platform.UnixCommands;
 
 public class MacosCommands extends UnixCommands {

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
@@ -5,12 +5,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-public interface AWSResourceLifecycle<Client> extends Closeable {
-    List<Class<? extends ResourceSpec<Client, ? extends AWSResource<Client>>>> getSupportedSpecs();
+public interface AWSResourceLifecycle<C> extends Closeable {
+    List<Class<? extends ResourceSpec<C, ? extends AWSResource<C>>>> getSupportedSpecs();
 
-    <U extends ResourceSpec<Client, R>, R extends AWSResource<Client>> U create(U spec, AWSResources resources);
+    <U extends ResourceSpec<C, R>, R extends AWSResource<C>> U create(U spec, AWSResources resources);
 
-    <U extends ResourceSpec<Client, R>, R extends AWSResource<Client>> Stream<U> trackingSpecs(Class<U> specClass);
+    <U extends ResourceSpec<C, R>, R extends AWSResource<C>> Stream<U> trackingSpecs(Class<U> specClass);
 
     void persist();
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
@@ -5,8 +5,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
@@ -20,8 +18,15 @@ public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLife
     protected List<ResourceSpec<C, ? extends AWSResource<C>>> specs;
     protected UUID uuid;
 
+    /**
+     * Create a {@link AWSResourceLifecycle} using a collection of tracking classes and underlying client.
+     *
+     * @param client A type of AWS client to handle the tracking {@link ResourceSpec}
+     * @param specClass a {@link ResourceSpec} implementation class
+     */
     @SafeVarargs
-    public AbstractAWSResourceLifecycle(C client, Class<? extends ResourceSpec<C, ? extends AWSResource<C>>> ... specClass) {
+    public AbstractAWSResourceLifecycle(C client,
+                                        Class<? extends ResourceSpec<C, ? extends AWSResource<C>>>...specClass) {
         this.client = client;
         this.specClasses = Arrays.asList(specClass);
         this.specs = new ArrayList<>();
@@ -76,8 +81,12 @@ public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLife
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         AbstractAWSResourceLifecycle<?> that = (AbstractAWSResourceLifecycle<?>) o;
         return Objects.equals(client, that.client)
                 && Objects.equals(specClasses, that.specClasses)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentModel.java
@@ -10,7 +10,9 @@ import software.amazon.awssdk.services.greengrassv2.model.DeleteComponentRequest
 @Value.Immutable
 interface GreengrassComponentModel extends AWSResource<GreengrassV2Client> {
     String componentName();
+
     String componentVersion();
+
     String componentArn();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
@@ -11,9 +11,9 @@ import software.amazon.awssdk.services.greengrassv2.model.DeleteCoreDeviceReques
 import software.amazon.awssdk.services.greengrassv2.model.GreengrassV2Exception;
 import software.amazon.awssdk.services.greengrassv2.model.ValidationException;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
@@ -11,19 +11,15 @@ import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentDeploymentSpecification;
 import software.amazon.awssdk.services.greengrassv2.model.CreateDeploymentRequest;
 import software.amazon.awssdk.services.greengrassv2.model.CreateDeploymentResponse;
-import software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicy;
-import software.amazon.awssdk.services.greengrassv2.model.DeploymentComponentUpdatePolicyAction;
-import software.amazon.awssdk.services.greengrassv2.model.DeploymentConfigurationValidationPolicy;
-import software.amazon.awssdk.services.greengrassv2.model.DeploymentFailureHandlingPolicy;
 import software.amazon.awssdk.services.greengrassv2.model.DeploymentIoTJobConfiguration;
 import software.amazon.awssdk.services.greengrassv2.model.DeploymentPolicies;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
@@ -6,8 +6,6 @@ import com.google.auto.service.AutoService;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentVersionListItem;
 import software.amazon.awssdk.services.greengrassv2.model.ComponentVisibilityScope;
-import software.amazon.awssdk.services.greengrassv2.model.DescribeComponentRequest;
-import software.amazon.awssdk.services.greengrassv2.model.GetComponentRequest;
 import software.amazon.awssdk.services.greengrassv2.model.GetCoreDeviceRequest;
 import software.amazon.awssdk.services.greengrassv2.model.GetCoreDeviceResponse;
 import software.amazon.awssdk.services.greengrassv2.model.GetDeploymentRequest;
@@ -20,8 +18,8 @@ import software.amazon.awssdk.services.greengrassv2.paginators.ListComponentVers
 import software.amazon.awssdk.services.greengrassv2.paginators.ListComponentsIterable;
 import software.amazon.awssdk.services.greengrassv2.paginators.ListEffectiveDeploymentsIterable;
 
-import javax.inject.Inject;
 import java.util.Optional;
+import javax.inject.Inject;
 
 @AutoService(AWSResourceLifecycle.class)
 public class GreengrassV2Lifecycle extends AbstractAWSResourceLifecycle<GreengrassV2Client> {
@@ -34,6 +32,12 @@ public class GreengrassV2Lifecycle extends AbstractAWSResourceLifecycle<Greengra
         this(GreengrassV2Client.create());
     }
 
+    /**
+     * Attempts to obtain the mapped Greengrass core device to IoT core.
+     *
+     * @param thingName IoT core thing name
+     * @return
+     */
     public Optional<GetCoreDeviceResponse> coreDevice(String thingName) {
         try {
             return Optional.ofNullable(client.getCoreDevice(GetCoreDeviceRequest.builder()
@@ -44,24 +48,48 @@ public class GreengrassV2Lifecycle extends AbstractAWSResourceLifecycle<Greengra
         }
     }
 
+    /**
+     * List effective deployments performed on the device by thing name.
+     *
+     * @param thingName Name of the core device. This matches the thing name used in IoT core.
+     * @return
+     */
     public ListEffectiveDeploymentsIterable listDeviceDeployments(String thingName) {
         return client.listEffectiveDeploymentsPaginator(ListEffectiveDeploymentsRequest.builder()
                 .coreDeviceThingName(thingName)
                 .build());
     }
 
+    /**
+     * Get a Greengrass deployment by ID.
+     *
+     * @param deploymentId ID of the Greengrass deployment
+     * @return
+     */
     public GetDeploymentResponse deployment(String deploymentId) {
         return client.getDeployment(GetDeploymentRequest.builder()
                 .deploymentId(deploymentId)
                 .build());
     }
 
+    /**
+     * List all component versions by fully qualified component ARN.
+     *
+     * @param arn Fully qualified AWS ARN
+     * @return
+     */
     public ListComponentVersionsIterable listComponentVersions(String arn) {
         return client.listComponentVersionsPaginator(ListComponentVersionsRequest.builder()
                 .arn(arn)
                 .build());
     }
 
+    /**
+     * Grabs the latest version of the Component by ARN.
+     *
+     * @param arn String AWS ARN of the Greengrass Component
+     * @return
+     */
     public Optional<ComponentVersionListItem> latestVersionFor(String arn) {
         return client.listComponentVersions(ListComponentVersionsRequest.builder()
                 .arn(arn)
@@ -72,6 +100,12 @@ public class GreengrassV2Lifecycle extends AbstractAWSResourceLifecycle<Greengra
                 .findFirst();
     }
 
+    /**
+     * List components by {@link ComponentVisibilityScope}.
+     *
+     * @param scope List all of the components by {@link ComponentVisibilityScope}
+     * @return
+     */
     public ListComponentsIterable listComponents(ComponentVisibilityScope scope) {
         return client.listComponentsPaginator(ListComponentsRequest.builder()
                 .scope(scope)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicyModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicyModel.java
@@ -4,11 +4,9 @@ import com.aws.greengrass.testing.api.model.TestingModel;
 import com.aws.greengrass.testing.resources.AWSResource;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iam.IamClient;
-import software.amazon.awssdk.services.iam.model.AttachedPolicy;
 import software.amazon.awssdk.services.iam.model.DeletePolicyRequest;
 import software.amazon.awssdk.services.iam.model.DetachRolePolicyRequest;
 import software.amazon.awssdk.services.iam.model.EntityType;
-import software.amazon.awssdk.services.iam.model.ListAttachedRolePoliciesRequest;
 import software.amazon.awssdk.services.iam.model.ListEntitiesForPolicyRequest;
 import software.amazon.awssdk.services.iam.model.PolicyRole;
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 @Value.Immutable
 interface IamPolicySpecModel extends ResourceSpec<IamClient, IamPolicy>, IamTaggingMixin {
     String policyName();
+
     String policyDocument();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleModel.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.iam.model.ListAttachedRolePoliciesRequest
 @Value.Immutable
 interface IamRoleModel extends AWSResource<IamClient> {
     String roleArn();
+
     String roleName();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
@@ -9,8 +9,6 @@ import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.AttachRolePolicyRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
-import software.amazon.awssdk.services.iam.model.UpdateAssumeRolePolicyRequest;
-import software.amazon.awssdk.services.iam.model.UpdateRoleRequest;
 
 import javax.annotation.Nullable;
 
@@ -20,8 +18,11 @@ import javax.annotation.Nullable;
 interface IamRoleSpecModel extends ResourceSpec<IamClient, IamRole>, IamTaggingMixin {
     @Nullable
     String policyArn();
+
     String roleName();
+
     String policyDocument();
+
     String trustDocument();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateModel.java
@@ -16,8 +16,11 @@ import software.amazon.awssdk.services.iot.model.UpdateCertificateRequest;
 @Value.Immutable
 interface IotCertificateModel extends AWSResource<IotClient> {
     String certificateArn();
+
     String certificateId();
+
     String certificatePem();
+
     KeyPair keyPair();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
@@ -10,8 +10,8 @@ import software.amazon.awssdk.services.iot.model.AttachThingPrincipalRequest;
 import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateRequest;
 import software.amazon.awssdk.services.iot.model.CreateKeysAndCertificateResponse;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
@@ -28,9 +28,10 @@ interface IotCertificateSpecModel extends ResourceSpec<IotClient, IotCertificate
 
     @Override
     default IotCertificateSpec create(IotClient client, AWSResources resources) {
-        CreateKeysAndCertificateResponse created = client.createKeysAndCertificate(CreateKeysAndCertificateRequest.builder()
-                .setAsActive(active())
-                .build());
+        CreateKeysAndCertificateResponse created = client.createKeysAndCertificate(
+                CreateKeysAndCertificateRequest.builder()
+                        .setAsActive(active())
+                        .build());
 
         client.attachThingPrincipal(AttachThingPrincipalRequest.builder()
                 .thingName(thingName())

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
@@ -16,6 +16,11 @@ public class IotLifecycle extends AbstractAWSResourceLifecycle<IotClient> {
     private static final String CREDENTIALS_ENDPOINT = "iot:CredentialProvider";
     private static final String DATA_ENDPOINT = "iot:Data-ATS";
 
+    /**
+     * Create a {@link IotLifecycle} with a customized {@link IotClient}.
+     *
+     * @param client Customized {@link IotClient}
+     */
     @Inject
     public IotLifecycle(final IotClient client) {
         super(client,
@@ -38,6 +43,12 @@ public class IotLifecycle extends AbstractAWSResourceLifecycle<IotClient> {
         return endpointType(DATA_ENDPOINT);
     }
 
+    /**
+     * List things for a group by name.
+     *
+     * @param thingGroupName String thing group name
+     * @return
+     */
     public ListThingsInThingGroupIterable listThingsForGroup(String thingGroupName) {
         return client.listThingsInThingGroupPaginator(ListThingsInThingGroupRequest.builder()
                 .recursive(true)

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.iot.model.DeletePolicyRequest;
 @Value.Immutable
 interface IotPolicyModel extends AWSResource<IotClient> {
     String policyArn();
+
     String policyName();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
@@ -6,7 +6,6 @@ import com.aws.greengrass.testing.resources.ResourceSpec;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iot.IotClient;
-import software.amazon.awssdk.services.iot.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.iot.model.CreatePolicyRequest;
 import software.amazon.awssdk.services.iot.model.CreatePolicyResponse;
 
@@ -17,6 +16,7 @@ import javax.annotation.Nullable;
 @JsonDeserialize(builder = IotPolicySpec.Builder.class)
 interface IotPolicySpecModel extends ResourceSpec<IotClient, IotPolicy>, IotTaggingMixin {
     String policyName();
+
     String policyDocument();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasModel.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.iot.model.DeleteRoleAliasRequest;
 @Value.Immutable
 interface IotRoleAliasModel extends AWSResource<IotClient> {
     String roleAlias();
+
     String roleAliasArn();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
@@ -1,7 +1,7 @@
 package com.aws.greengrass.testing.resources.iot;
 
-import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.api.model.TestingModel;
+import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.resources.ResourceSpec;
 import com.aws.greengrass.testing.resources.iam.IamRole;
 import org.immutables.value.Value;
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
 @Value.Immutable
 interface IotRoleAliasSpecModel extends ResourceSpec<IotClient, IotRoleAlias>, IotTaggingMixin {
     String name();
+
     IamRole iamRole();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupModel.java
@@ -10,7 +10,9 @@ import software.amazon.awssdk.services.iot.model.DeleteThingGroupRequest;
 @Value.Immutable
 interface IotThingGroupModel extends AWSResource<IotClient> {
     String groupId();
+
     String groupArn();
+
     String groupName();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 @Value.Immutable
 interface IotThingGroupSpecModel extends ResourceSpec<IotClient, IotThingGroup>, IotTaggingMixin {
     String groupName();
+
     @Nullable
     String parentGroupName();
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
@@ -8,27 +8,32 @@ import software.amazon.awssdk.services.iot.model.DeleteThingRequest;
 import software.amazon.awssdk.services.iot.model.DetachThingPrincipalRequest;
 import software.amazon.awssdk.services.iot.model.ListThingPrincipalsRequest;
 
-import javax.annotation.Nullable;
 import java.util.List;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
 interface IotThingModel extends AWSResource<IotClient> {
     String thingName();
+
     String thingId();
+
     String thingArn();
+
     List<IotThingGroup> thingGroups();
+
     @Nullable
     IotCertificate certificate();
 
     @Override
     default void remove(IotClient client) {
-        client.listThingPrincipals(ListThingPrincipalsRequest.builder().thingName(thingName()).build()).principals().forEach(p -> {
-            client.detachThingPrincipal(DetachThingPrincipalRequest.builder()
-                    .thingName(thingName())
-                    .principal(p)
-                    .build());
-        });
+        client.listThingPrincipals(ListThingPrincipalsRequest.builder().thingName(thingName()).build()).principals()
+                .forEach(p -> {
+                    client.detachThingPrincipal(DetachThingPrincipalRequest.builder()
+                            .thingName(thingName())
+                            .principal(p)
+                            .build());
+                });
         client.deleteThing(DeleteThingRequest.builder()
                 .thingName(thingName())
                 .build());

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
@@ -9,11 +9,11 @@ import software.amazon.awssdk.services.iot.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.iot.model.CreateThingRequest;
 import software.amazon.awssdk.services.iot.model.CreateThingResponse;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 @TestingModel
 @Value.Immutable
@@ -47,10 +47,10 @@ interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing>, IotTaggin
             updatedRoleAlias = resources.create(roleAliasSpec());
             assumeRolePolicy = resources.create(IotPolicySpec.builder()
                     .policyName(policySpec().policyName() + "-credentials")
-                    .policyDocument("{\"Version\":\"2012-10-17\",\"Statement\":[{" +
-                            "\"Effect\":\"Allow\"," +
-                            "\"Action\":\"iot:AssumeRoleWithCertificate\"," +
-                            "\"Resource\":\"" + updatedRoleAlias.resource().roleAliasArn() + "\"}]}")
+                    .policyDocument("{\"Version\":\"2012-10-17\",\"Statement\":[{"
+                            + "\"Effect\":\"Allow\","
+                            + "\"Action\":\"iot:AssumeRoleWithCertificate\","
+                            + "\"Resource\":\"" + updatedRoleAlias.resource().roleAliasArn() + "\"}]}")
                     .build());
         }
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketModel.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 @Value.Immutable
 interface S3BucketModel extends AWSResource<S3Client> {
     String location();
+
     String bucketName();
 
     @Override

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Lifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Lifecycle.java
@@ -20,6 +20,12 @@ public class S3Lifecycle extends AbstractAWSResourceLifecycle<S3Client> {
         this(S3Client.create());
     }
 
+    /**
+     * Checks if the bucket exists by name.
+     *
+     * @param bucketName Name of the bucket to check
+     * @return
+     */
     public boolean bucketExists(String bucketName) {
         try {
             client.headBucket(HeadBucketRequest.builder()

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectModel.java
@@ -12,8 +12,11 @@ import javax.annotation.Nullable;
 @Value.Immutable
 interface S3ObjectModel extends AWSResource<S3Client> {
     String etag();
+
     String key();
+
     String bucket();
+
     @Nullable
     String versionId();
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
@@ -16,7 +16,9 @@ import javax.annotation.Nullable;
 @Value.Immutable
 interface S3ObjectSpecModel extends ResourceSpec<S3Client, S3Object>, S3TaggingMixin {
     String key();
+
     String bucket();
+
     RequestBody content();
 
     @Nullable

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -1,0 +1,344 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Amazon.com Inc. or its affiliates.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.org/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="severity" value="warning"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="SuppressWarningsFilter" />
+    <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format"
+                      value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+                      value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="severity" value="warning"/>
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+        </module>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces">
+            <property name="tokens"
+                      value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+        </module>
+        <module name="LeftCurly">
+            <property name="tokens"
+                      value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens"
+                      value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens"
+                      value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <property name="tokens"
+                      value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                     LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+            <message key="ws.notFollowed"
+                     value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+            <message key="ws.notPreceded"
+                     value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="severity" value="warning"/>
+            <property name="tokens"
+                      value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF"/>
+            <message key="name.invalidPattern"
+                     value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="severity" value="warning"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="severity" value="warning"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="severity" value="warning"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="severity" value="warning"/>
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="4"/>
+            <property name="tokens"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="VariableDeclarationUsageDistance">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
+            <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+        </module>
+        <module name="MethodParamPad">
+            <property name="tokens"
+                      value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+                      value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="ParenPad">
+            <property name="tokens"
+                      value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens"
+                      value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocTagContinuationIndentation">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="SummaryJavadoc">
+            <property name="severity" value="warning"/>
+            <property name="forbiddenSummaryFragments"
+                      value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="AtclauseOrder">
+            <property name="severity" value="warning"/>
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target"
+                      value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="severity" value="warning"/>
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="false"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="validateThrows" value="true"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="severity" value="warning"/>
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="severity" value="warning"/>
+            <property name="exceptionVariableName" value="expected|ignore"/>
+        </module>
+        <module name="CommentsIndentation">
+            <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+        </module>
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,38 @@
         <iotdevicesdk.version>1.3.3</iotdevicesdk.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.29</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <configLocation>codestyle/checkstyle.xml</configLocation>
+                    <violationSeverity>warning</violationSeverity>
+                    <maxAllowedViolations>0</maxAllowedViolations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This looks like a frightening large change, because it...

Adds and applies Greengrass checkstyle guide. This means that the following were added:

- Java docs to all used public methods
- Import ordering to all imports
- Spacing around interface methods

**Why is this change necessary:**

This repository was not using the checkstyle standards through out the other open source repos.

**How was this change tested:**

```
mvn -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
