### PR TITLE
fix: dropping MQTT dep from the ml test

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-ml/src/main/resources/greengrass/features/ml.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-ml/src/main/resources/greengrass/features/ml.feature
@@ -5,8 +5,10 @@ Feature: Greengrass V2 Machine Learning
     And my device is running Greengrass
 
   @ML @DLR
-  Scenario: I can receive inference results after installing aws.greengrass.DLRImageClassification
-    Given I create a Greengrass deployment with components
+  Scenario: I can receive inference results on an MQTT topic after installing aws.greengrass.DLRImageClassification
+    Given I subscribe to the following IoT MQTT topics
+      | image/classification |
+    And I create a Greengrass deployment with components
       | aws.greengrass.DLRImageClassification | LATEST |
     When I update my Greengrass deployment configuration, setting the component aws.greengrass.DLRImageClassification configuration to:
       """
@@ -17,22 +19,25 @@ Feature: Greengrass V2 Machine Learning
                 "aws.greengrass.DLRImageClassification:mqttproxy:1": {
                   "policyDescription": "Allows access to publish via topic image/classification.",
                     "operations": ["aws.greengrass#PublishToIoTCore"],
-                    "resources": ["dlr/${test.id}/image/classification"]
+                    "resources": ["${image/classification}"]
                 }
               }
             },
-            "PublishResultsOnTopic": "dlr/${test.id}/image/classification",
+            "PublishResultsOnTopic": "${image/classification}",
             "InferenceInterval": "10"
           }
         }
       """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the aws.greengrass.DLRImageClassification log on the device contains the line "image-classification" within 30 seconds
+    And I receive messages on the following IoT MQTT topics after 30 seconds
+      | image/classification | image-classification
 
   @ML @TensorFlow
-  Scenario: I can receive image inference results after installing aws.greengrass.TensorFlowLiteImageClassification
-    Given I create a Greengrass deployment with components
+  Scenario: I can receive inference results on an MQTT topic after installing aws.greengrass.TensorFlowLiteImageClassification
+    Given I subscribe to the following IoT MQTT topics
+      | image/classification |
+    And I create a Greengrass deployment with components
       | aws.greengrass.TensorFlowLiteImageClassification | LATEST |
     When I update my Greengrass deployment configuration, setting the component aws.greengrass.TensorFlowLiteImageClassification configuration to:
       """
@@ -43,18 +48,19 @@ Feature: Greengrass V2 Machine Learning
                 "aws.greengrass.TensorFlowLiteImageClassification:mqttproxy:1": {
                   "policyDescription": "Allows access to publish via topic image/classification.",
                     "operations": ["aws.greengrass#PublishToIoTCore"],
-                    "resources": ["tensorflow/${test.id}/image/classification"]
+                    "resources": ["${image/classification}"]
                 }
               }
             },
-            "PublishResultsOnTopic": "tensorflow/${test.id}/image/classification",
+            "PublishResultsOnTopic": "${image/classification}",
             "InferenceInterval": "10"
           }
         }
       """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the aws.greengrass.TensorFlowLiteImageClassification log on the device contains the line "image-classification" within 30 seconds
+    And I receive messages on the following IoT MQTT topics after 30 seconds
+      | image/classification | image-classification
 
   @ML @SageMakerEdgeManager
   Scenario: I can install SageMaker Edge Manager agent using aws.greengrass.SageMakerEdgeManager component

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
@@ -46,6 +46,7 @@ import javax.inject.Inject;
 @ScenarioScoped
 public class MQTTSteps {
     private static final Logger LOGGER = LogManager.getLogger(MQTTSteps.class);
+    private static final short PORT = 443;
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
     private final AWSResources resources;
@@ -102,6 +103,7 @@ public class MQTTSteps {
                         .withCertificateAuthority(registrationContext.rootCA())
                         .withCleanSession(false)
                         .withEndpoint(lifecycle.dataEndpoint())
+                        .withPort(PORT)
                         .build();
 
                 connection.connect().get();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Dropping host agent dependency on MQTT to qualify ML tests. It's not necessary.

**Why is this change necessary:**

Reduce the variability in the qualification test by eliminating unnecessary dependency to qualify things.

**How was this change tested:**

- Ran both `DLR` and `TensorFlow` tests to confirm they continue to pass.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
