### PR TITLE
chore: add and apply license plugin

### DIFF
--- a/.license/header.txt
+++ b/.license/header.txt
@@ -1,0 +1,2 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/.license/style.xml
+++ b/.license/style.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<additionalHeaders>
+    <java_style>
+        <firstLine>/*</firstLine>
+        <beforeEachLine> * </beforeEachLine>
+        <endLine> */EOL</endLine>
+        <firstLineDetectionPattern>(\\s|\\t)*/\\*.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern>.*\\*/(\\s|\\t)*$</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </java_style>
+</additionalHeaders>

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/ComponentPreparationService.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/ComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api;
 
 import com.aws.greengrass.testing.api.model.ComponentOverrideNameVersion;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/Greengrass.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/Greengrass.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api;
 
 public interface Greengrass {

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/TestRuns.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/TestRuns.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api;
 
 import com.aws.greengrass.testing.api.model.TestRun;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device;
 
 

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CommandExecutionException.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CommandExecutionException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device.exception;
 
 

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CopyException.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/exception/CopyException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device.exception;
 
 import java.nio.file.Path;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device.local;
 
 

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/CommandInputModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/CommandInputModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device.model;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/PlatformOSModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/model/PlatformOSModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.device.model;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/CleanupContext.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideNameVersionModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideNameVersionModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideVersionModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverrideVersionModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverridesModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ComponentOverridesModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/PersistMode.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import java.util.Arrays;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ProxyConfig.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/ProxyConfig.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestIdModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestIdModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestRunModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestingModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TestingModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/model/TimeoutMultiplierModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.model;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/util/FileUtils.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/util/FileUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.api.util;
 
 import java.io.File;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/IPCModule.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/IPCModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import dagger.Module;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Paddle.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Paddle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPC;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PaddleComponent.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PaddleComponent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import dagger.Component;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Ping.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Ping.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPC;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PingPong.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/PingPong.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import java.util.concurrent.ExecutionException;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Pong.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/src/main/java/com/aws/greengrass/testing/examples/component/Pong.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.component;
 
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPC;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleSteps.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.standalone;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleStepsModule.java
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-standalone/src/main/java/com/aws/greengrass/testing/examples/standalone/ExampleStepsModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.examples.standalone;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing;
 
 import com.aws.greengrass.testing.api.Greengrass;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/ScenarioTestRuns.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing;
 
 import com.aws.greengrass.testing.api.TestRuns;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/ClasspathComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/ClasspathComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.component;
 
 import com.aws.greengrass.testing.api.model.ComponentOverrides;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.component;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CompositeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CompositeComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.component;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.component;
 
 import com.aws.greengrass.testing.api.model.ComponentOverrides;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.component;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.model.TestContext;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.Greengrass;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.model.TestContext;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/ScenarioTrackerSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.TestRuns;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.model.TimeoutMultiplier;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.model;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/RegistrationContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/RegistrationContextModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.model;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/ScenarioContext.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/ScenarioContext.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.model;
 
 import com.aws.greengrass.testing.api.model.TestId;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.model;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/ComponentPreparationModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/ComponentPreparationModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/DeviceModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.DefaultGreengrass;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/JacksonModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/JacksonModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/PlatformModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/PlatformModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/RegistrationContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/RegistrationContextModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.ProxyConfig;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.ScenarioTestRuns;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.device.model.CommandInput;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.features.mqtt;
 
 import com.aws.greengrass.testing.features.IotSteps;

--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.launcher;
 
 import com.aws.greengrass.testing.launcher.reporting.StepTrackingReporting;

--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/reporting/StepTrackingReporting.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/reporting/StepTrackingReporting.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.launcher.reporting;
 
 import io.cucumber.plugin.EventListener;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesCleanupModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesCleanupModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AbstractAWSResourceModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AbstractAWSResourceModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/ComponentOverridesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/ComponentOverridesModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.aws.greengrass.testing.api.model.ComponentOverrideVersion;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/GreengrassInjectorSource.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/GreengrassInjectorSource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules;
 
 import com.google.inject.Guice;

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/exception/ModuleProvisionException.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/exception/ModuleProvisionException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules.exception;
 
 public class ModuleProvisionException extends RuntimeException {

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/model/AWSResourcesContextModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.modules.model;
 
 import com.aws.greengrass.testing.api.model.ProxyConfig;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/Commands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/Commands.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/Platform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/Platform.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 public interface Platform {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform;
 
 

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/exception/PlatformResolutionException.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/exception/PlatformResolutionException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.exception;
 
 public class PlatformResolutionException extends RuntimeException {

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxCommands.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.platform.Commands;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.linux;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosCommands.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.macos;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosFiles.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.macos;
 
 import com.aws.greengrass.testing.platform.Commands;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.macos;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.windows;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsPlatform.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.platform.windows;
 
 import com.aws.greengrass.testing.api.device.Device;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResource.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 public interface AWSResource<C> {

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResourceLifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 import java.io.Closeable;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResources.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AWSResources.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 import com.aws.greengrass.testing.api.model.CleanupContext;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 import org.apache.logging.log4j.LogManager;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceSpec.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceSpec.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 import org.immutables.value.Value;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceTagMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceTagMixin.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources;
 
 import java.util.Collection;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassComponentSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Module.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Module.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.greengrass;
 
 import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamModule.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicyModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicyModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamPolicySpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamTaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamTaggingMixin.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.resources.ResourceTagMixin;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotCertificateSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotModule.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotModule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicySpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotTaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotTaggingMixin.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.resources.ResourceTagMixin;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingGroupSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.iot;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3BucketSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Lifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Lifecycle.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.resources.AWSResourceLifecycle;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Module.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3Module.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.modules.AbstractAWSResourceModule;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3ObjectSpecModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.api.model.TestingModel;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3TaggingMixin.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/src/main/java/com/aws/greengrass/testing/resources/s3/S3TaggingMixin.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.testing.resources.s3;
 
 import com.aws.greengrass.testing.resources.ResourceTagMixin;

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,39 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>4.0.rc2</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>.license/header.txt</header>
+                            <headerDefinitions>
+                                <headerDefinition>.license/style.xml</headerDefinition>
+                            </headerDefinitions>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <excludes>
+                                <exclude>*</exclude>
+                                <exclude>codestyle/**</exclude>
+                                <exclude>src/*/resources/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                        <cmd>BATCH</cmd>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.2</version>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Making sure all source contains the license header
- license header format is enforced at build time

**Why is this change necessary:**

Licenses... amirite?

**How was this change tested:**

```
mvn clean compile
```

Failed initially. Then:

```
mvn license:format
mvn clean compile
```

Passed.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
