### PR TITLE
fix: more platform fixes and file abstraction

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/Device.java
@@ -32,12 +32,7 @@ public interface Device {
         return new String(execute(input), StandardCharsets.UTF_8);
     }
 
-    void copyTo(Path source, Path destination) throws CopyException;
+    boolean exists(String path);
 
-    default void sync(Path source) throws CopyException {
-        copyTo(source, source);
-    }
-
-    boolean exists(Path file);
-
+    void copyTo(String source, String destination) throws CopyException;
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -28,18 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FileSteps {
     private static final Logger LOGGER = LogManager.getLogger(FileSteps.class);
     private static final int DEFAULT_TIMEOUT = 30;
-    private final Device device;
     private final Platform platform;
     private final TestContext testContext;
     private final WaitSteps waits;
 
     @Inject
     FileSteps(
-            Device device,
             Platform platform,
             TestContext testContext,
             WaitSteps waits) {
-        this.device = device;
         this.platform = platform;
         this.testContext = testContext;
         this.waits = waits;
@@ -47,7 +44,7 @@ public class FileSteps {
 
     @Then("the file {word} on device exists")
     public void checkFileExists(String file) {
-        assertTrue(device.exists(testContext.installRoot().resolve(file)),
+        assertTrue(platform.files().exists(testContext.installRoot().resolve(file)),
                 "file " + file + " does not exist in " + testContext.installRoot());
     }
 
@@ -93,7 +90,7 @@ public class FileSteps {
     @After(order = 99899)
     public void copyLogs(final Scenario scenario) {
         Path logFolder = testContext.installRoot().resolve("logs");
-        if (device.exists(logFolder)) {
+        if (platform.files().exists(logFolder)) {
             platform.files().listContents(logFolder).forEach(logFile -> {
                 byte[] bytes = platform.files().readBytes(logFile);
                 scenario.attach(bytes, "text/plain", logFile.getFileName().toString());

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.testing.api.Greengrass;
 import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.platform.Platform;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
@@ -24,17 +25,17 @@ public class GreengrassSteps implements Closeable {
     private final Greengrass greengrass;
     private final GreengrassContext greengrassContext;
     private final TestContext testContext;
-    private final Device device;
+    private final Platform platform;
     private final FileSteps files;
 
     @Inject
     GreengrassSteps(
-            final Device device,
+            final Platform platform,
             final Greengrass greengrass,
             final GreengrassContext greengrassContext,
             final TestContext testContext,
             final FileSteps files) {
-        this.device = device;
+        this.platform = platform;
         this.greengrass = greengrass;
         this.greengrassContext = greengrassContext;
         this.testContext = testContext;
@@ -46,7 +47,7 @@ public class GreengrassSteps implements Closeable {
      */
     @When("I install Greengrass")
     public void install() {
-        device.copyTo(greengrassContext.greengrassPath(), testContext.installRoot().resolve("greengrass"));
+        platform.files().copyTo(greengrassContext.greengrassPath(), testContext.installRoot().resolve("greengrass"));
         greengrass.install();
         files.checkFileExists("logs/greengrass.log");
     }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -48,12 +48,10 @@ public class RegistrationSteps {
     private final AWSResources resources;
     private final IamSteps iamSteps;
     private final IotSteps iotSteps;
-    private final Device device;
     private final Platform platform;
 
     @Inject
     RegistrationSteps(
-            Device device,
             Platform platform,
             AWSResources resources,
             IamSteps iamSteps,
@@ -62,7 +60,6 @@ public class RegistrationSteps {
             RegistrationContext registrationContext,
             GreengrassContext greengrassContext,
             AWSResourcesContext resourcesContext) {
-        this.device = device;
         this.platform = platform;
         this.resources = resources;
         this.iamSteps = iamSteps;
@@ -155,6 +152,6 @@ public class RegistrationSteps {
         Files.write(configFilePath.resolve("config.yaml"), config.getBytes(StandardCharsets.UTF_8));
         // Copy to where the nucleus will read it
         platform.files().makeDirectories(testContext.installRoot().getParent());
-        device.copyTo(testContext.testDirectory(), testContext.installRoot());
+        platform.files().copyTo(testContext.testDirectory(), testContext.installRoot());
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/DevicePredicatePlatformFiles.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
+import com.aws.greengrass.testing.api.device.exception.CopyException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,7 +43,7 @@ public class DevicePredicatePlatformFiles implements PlatformFiles {
     }
 
     public static PlatformFiles localOrRemote(final Device device, final PlatformFiles remote) {
-        return new DevicePredicatePlatformFiles(d -> d.type().equals("LOCAL"), device, new LocalFiles(), remote);
+        return new DevicePredicatePlatformFiles(d -> d.type().equals("LOCAL"), device, new LocalFiles(device), remote);
     }
 
     private <T> T delegate(Function<PlatformFiles, T> thunk) {
@@ -52,6 +53,19 @@ public class DevicePredicatePlatformFiles implements PlatformFiles {
         }
         LOGGER.debug("Using file provider {}", files);
         return thunk.apply(files);
+    }
+
+    @Override
+    public boolean exists(Path filePath) throws CommandExecutionException {
+        return delegate(files -> files.exists(filePath));
+    }
+
+    @Override
+    public void copyTo(Path source, Path destination) throws CopyException {
+        delegate(files -> {
+            files.copyTo(source, destination);
+            return null;
+        });
     }
 
     @Override

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/LocalFiles.java
@@ -5,12 +5,15 @@
 
 package com.aws.greengrass.testing.platform;
 
+import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
+import com.aws.greengrass.testing.api.device.exception.CopyException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.util.FileUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -19,6 +22,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class LocalFiles implements PlatformFiles {
+    private final Device localDevice;
+
+    public LocalFiles(final Device localDevice) {
+        this.localDevice = localDevice;
+    }
+
     @Override
     public byte[] readBytes(Path filePath) throws CommandExecutionException {
         try {
@@ -44,6 +53,16 @@ public class LocalFiles implements PlatformFiles {
         } catch (IOException e) {
             throw new CommandExecutionException(e, CommandInput.of("makeDirectories: " + filePath));
         }
+    }
+
+    @Override
+    public boolean exists(Path filePath) throws CommandExecutionException {
+        return localDevice.exists(filePath.toString());
+    }
+
+    @Override
+    public void copyTo(Path source, Path destination) throws CopyException {
+        localDevice.copyTo(source.toString(), destination.toString());
     }
 
     @Override

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
@@ -27,6 +27,10 @@ public interface PlatformFiles {
 
     List<Path> listContents(Path filePath) throws CommandExecutionException;
 
+    void copyTo(Path source, Path destination) throws CopyException;
+
+    boolean exists(Path filePath) throws CommandExecutionException;
+
     /**
      * Perform a recursive copy from remote source to local destination.
      *

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
@@ -59,17 +59,17 @@ public class PlatformResolver {
         if (device.platform().isWindows()) {
             ranks.put("windows", 5);
         } else {
-            if (device.exists(Paths.get("/bin/bash")) || device.exists(Paths.get("/usr/bin/bash"))) {
+            if (device.exists("/bin/bash") || device.exists("/usr/bin/bash")) {
                 ranks.put("unix", 3);
                 ranks.put("posix", 3);
             }
-            if (device.exists(Paths.get("/proc"))) {
+            if (device.exists("/proc")) {
                 ranks.put("linux", 10);
             }
-            if (device.exists(Paths.get("/usr/bin/apt-get"))) {
+            if (device.exists("/usr/bin/apt-get")) {
                 ranks.put("debian", 11);
             }
-            if (device.exists(Paths.get("/usr/bin/yum"))) {
+            if (device.exists("/usr/bin/yum")) {
                 ranks.put("fedora", 11);
             }
             String sysver = device.executeToString(CommandInput.builder()

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -22,7 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public abstract class UnixCommands implements Commands {
+public abstract class UnixCommands implements Commands, UnixPathsMixin {
     private static final Pattern PID_REGEX = Pattern.compile("^(\\d*)\\s*");
     protected final Device device;
     private final PlatformOS host;
@@ -32,13 +32,9 @@ public abstract class UnixCommands implements Commands {
         this.host = PlatformOS.currentPlatform();
     }
 
-    private String formatToUnixPath(String incoming) {
-        if (host.isWindows()) {
-            return incoming
-                    .replaceAll("^[A-Za-z]:", "")
-                    .replace("\\", "/");
-        }
-        return incoming;
+    @Override
+    public PlatformOS host() {
+        return host;
     }
 
     @Override

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
@@ -6,8 +6,11 @@
 package com.aws.greengrass.testing.platform;
 
 
+import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
+import com.aws.greengrass.testing.api.device.exception.CopyException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
+import com.aws.greengrass.testing.api.device.model.PlatformOS;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,11 +18,26 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class UnixFiles implements PlatformFiles {
+public abstract class UnixFiles implements PlatformFiles, UnixPathsMixin {
     protected final Commands commands;
+    private final Device device;
+    private final PlatformOS host;
 
-    public UnixFiles(Commands commands) {
+    /**
+     * A unix based platform. All commands and paths are formatted appropriately.
+     *
+     * @param commands the {@link Commands} interface this platform will interact with
+     * @param device the underlying {@link Device} this platform interacts with
+     */
+    public UnixFiles(Commands commands, Device device) {
+        this.host = PlatformOS.currentPlatform();
+        this.device = device;
         this.commands = commands;
+    }
+
+    @Override
+    public PlatformOS host() {
+        return host;
     }
 
     @Override
@@ -35,6 +53,16 @@ public abstract class UnixFiles implements PlatformFiles {
     @Override
     public void makeDirectories(Path filePath) throws CommandExecutionException {
         commands.execute(CommandInput.of("mkdir -p " + filePath.toString()));
+    }
+
+    @Override
+    public boolean exists(Path filePath) throws CommandExecutionException {
+        return device.exists(formatToUnixPath(filePath.toString()));
+    }
+
+    @Override
+    public void copyTo(Path source, Path destination) throws CopyException {
+        device.copyTo(source.toAbsolutePath().toString(), formatToUnixPath(destination.toString()));
     }
 
     @Override

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixPathsMixin.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/UnixPathsMixin.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.platform;
+
+import com.aws.greengrass.testing.api.device.model.PlatformOS;
+
+interface UnixPathsMixin {
+    PlatformOS host();
+
+    default String formatToUnixPath(String incoming) {
+        if (host().isWindows()) {
+            return incoming
+                    .replaceAll("^[A-Za-z]:", "")
+                    .replace("\\", "/");
+        }
+        return incoming;
+    }
+}

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxFiles.java
@@ -5,11 +5,12 @@
 
 package com.aws.greengrass.testing.platform.linux;
 
+import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.platform.Commands;
 import com.aws.greengrass.testing.platform.UnixFiles;
 
 public class LinuxFiles extends UnixFiles {
-    public LinuxFiles(final Commands commands) {
-        super(commands);
+    public LinuxFiles(final Commands commands, final Device device) {
+        super(commands, device);
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxPlatform.java
@@ -26,6 +26,6 @@ public class LinuxPlatform implements Platform {
 
     @Override
     public PlatformFiles files() {
-        return DevicePredicatePlatformFiles.localOrRemote(device, new LinuxFiles(commands()));
+        return DevicePredicatePlatformFiles.localOrRemote(device, new LinuxFiles(commands(), device));
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosFiles.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosFiles.java
@@ -5,11 +5,12 @@
 
 package com.aws.greengrass.testing.platform.macos;
 
+import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.platform.Commands;
 import com.aws.greengrass.testing.platform.UnixFiles;
 
 public class MacosFiles extends UnixFiles {
-    public MacosFiles(Commands commands) {
-        super(commands);
+    public MacosFiles(Commands commands, Device device) {
+        super(commands, device);
     }
 }

--- a/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
+++ b/aws-greengrass-testing-platform/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
@@ -26,6 +26,6 @@ public class MacosPlatform implements Platform {
 
     @Override
     public PlatformFiles files() {
-        return DevicePredicatePlatformFiles.localOrRemote(device, new MacosFiles(commands()));
+        return DevicePredicatePlatformFiles.localOrRemote(device, new MacosFiles(commands(), device));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

In anticipation of more path failures on mismatch host / DUT platform OS's, this change attempts to supply a complete platform abstraction over the device based FS interactions. This has two benefits:

1. No more direct usage of the `Device` in any steps. All direct device interaction is handle by the `Platform` which is how it's supposed to be.
2. Keeps the device interaction to "only as needed" and the "lowest possible primitive", which makes implementation concise and less error prone (ie: IDTDevice).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
