### PR TITLE
fix: cleanup added images and adding plugin repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,25 @@
         </dependencies>
     </dependencyManagement>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>yle-public</id>
+            <name>Yle public repository</name>
+            <url>https://d2x444wtt5plvm.cloudfront.net/release</url>
+            <layout>default</layout>
+        </pluginRepository>
+    </pluginRepositories>
+
     <distributionManagement>
         <snapshotRepository>
             <id>greengrass-dev-snapshot</id>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Tracking docker images to cleanup. Initially pretty naive, but it's better than not cleaning.
- Adding plugin repo for the maven upload.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
