### PR TITLE
feat: adding flags for logging output

### DIFF
--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
@@ -68,6 +68,8 @@
                                       newenvironment="true"
                                       classpathref="maven.test.classpath">
                                     <!-- <sysproperty key="aws.region" value="us-east-1"/> -->
+                                    <sysproperty key="test.log.path"
+                                                 value="${project.build.directory}/gg-features"/>
                                     <sysproperty key="ggc.archive" value="greengrass-nucleus-latest.zip"/>
                                     <sysproperty key="gg.component.overrides" value="com.aws.PingPong:file:${project.basedir}/recipe.yaml"/>
                                 </java>

--- a/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
+++ b/aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/AWSResourcesModule.java
@@ -65,6 +65,8 @@ public class AWSResourcesModule extends AbstractModule {
             final Region region) {
         // -Denv.stage or ENV_STAGE environment or prod
         final String stage = Optional.ofNullable(System.getProperty(ENV_STAGE, System.getenv("ENV_STAGE")))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .orElse("prod");
         return AWSResourcesContext.builder()
                 .envStage(stage)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Flags around files that get created as part of the logging
- Can disable junit XML on systems that don't need it
- Can disable junit console output and instead write to a file

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
