### PR TITLE
fix: use the https protocol instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/lib/streammanager"]
 	path = aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/lib/streammanager
-	url = git@github.com:aws-greengrass/aws-greengrass-stream-manager-sdk-java.git
+	url = https://github.com/aws-greengrass/aws-greengrass-stream-manager-sdk-java.git


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Use the public URL for cloning to simplify builds

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
