### PR TITLE
fix: allow platform read for perinstalled versions

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -47,7 +47,6 @@ public class DeploymentSteps {
     private final ComponentPreparationService componentPreparation;
     private final ComponentOverrides overrides;
     private final TestContext testContext;
-    private final GreengrassContext greengrassContext;
     private final WaitSteps waits;
     private final ObjectMapper mapper;
     private final ScenarioContext scenarioContext;
@@ -58,7 +57,6 @@ public class DeploymentSteps {
             final AWSResources resources,
             final ComponentOverrides overrides,
             final TestContext testContext,
-            final GreengrassContext greengrassContext,
             final ComponentPreparationService componentPreparation,
             final ScenarioContext scenarioContext,
             final WaitSteps waits,
@@ -66,7 +64,6 @@ public class DeploymentSteps {
         this.resources = resources;
         this.overrides = overrides;
         this.testContext = testContext;
-        this.greengrassContext = greengrassContext;
         this.componentPreparation = componentPreparation;
         this.scenarioContext = scenarioContext;
         this.waits = waits;
@@ -85,7 +82,7 @@ public class DeploymentSteps {
         final Map<String, ComponentDeploymentSpecification> components =
                 new HashMap<String, ComponentDeploymentSpecification>() {{
                     put("aws.greengrass.Nucleus", ComponentDeploymentSpecification.builder()
-                            .componentVersion(greengrassContext.version())
+                            .componentVersion(testContext.coreVersion())
                             .build());
                 }};
         LOGGER.debug("Potential overrides: {}", overrides);

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -43,7 +43,6 @@ public class RegistrationSteps {
     private final TestContext testContext;
     private final RegistrationContext registrationContext;
     private final AWSResourcesContext resourcesContext;
-    private final GreengrassContext greengrassContext;
     private final AWSResources resources;
     private final IamSteps iamSteps;
     private final IotSteps iotSteps;
@@ -57,14 +56,12 @@ public class RegistrationSteps {
             IotSteps iotSteps,
             TestContext testContext,
             RegistrationContext registrationContext,
-            GreengrassContext greengrassContext,
             AWSResourcesContext resourcesContext) {
         this.platform = platform;
         this.resources = resources;
         this.iamSteps = iamSteps;
         this.testContext = testContext;
         this.registrationContext = registrationContext;
-        this.greengrassContext = greengrassContext;
         this.resourcesContext = resourcesContext;
         this.iotSteps = iotSteps;
     }
@@ -150,7 +147,7 @@ public class RegistrationSteps {
         config = config.replace("{proxy_url}",
                 resourcesContext.proxyConfig().map(ProxyConfig::proxyUrl).orElse(""));
         config = config.replace("{aws_region}", resourcesContext.region().metadata().id());
-        config = config.replace("{nucleus_version}", greengrassContext.version());
+        config = config.replace("{nucleus_version}", testContext.coreVersion());
         config = config.replace("{env_stage}", resourcesContext.envStage());
         config = config.replace("{posix_user}", testContext.currentUser());
         config = config.replace("{data_plane_port}", Integer.toString(registrationContext.connectionPort()));

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/GreengrassContextModel.java
@@ -13,10 +13,13 @@ import org.immutables.value.Value;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
+
 
 @TestingModel
 @Value.Immutable
 interface GreengrassContextModel extends Closeable {
+    @Nullable
     String version();
 
     Path tempDirectory();

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
@@ -39,6 +39,8 @@ interface TestContextModel extends Closeable {
 
     String coreThingName();
 
+    String coreVersion();
+
     @Override
     default void close() throws IOException {
         if (!cleanupContext().persistGeneratedFiles()) {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -39,7 +39,6 @@ import javax.inject.Named;
 public class GreengrassContextModule extends AbstractModule {
     private static final Logger LOGGER = LogManager.getLogger(GreengrassContextModule.class);
     static String DEFAULT_NUCLEUS_VERSION;
-    static String DEFAULT_CORE_THING_NAME;
 
     static void extractZip(ObjectMapper mapper, Path archivePath, Path stagingPath) throws IOException {
         LOGGER.info("Extracting {} into {}", archivePath, stagingPath);
@@ -92,16 +91,6 @@ public class GreengrassContextModule extends AbstractModule {
                                 + FeatureParameters.NUCLEUS_ARCHIVE_PATH + " is required if not testing against "
                                 + "pre-installed versions of Greengrass on the device."));
                 extractZip(mapper, archivePath, tempDirectory.resolve("greengrass"));
-            } else {
-                Path installRoot = parameterValues.getString(FeatureParameters.NUCLEUS_INSTALL_ROOT)
-                        .map(Paths::get)
-                        .filter(Files::exists)
-                        .orElseThrow(() -> new IllegalArgumentException("Parameter "
-                                + FeatureParameters.NUCLEUS_INSTALL_ROOT + " must exist with a valid registration."));
-                Path effectiveConfig = installRoot.resolve("config").resolve("effectiveConfig.yaml");
-                JsonNode config = mapper.readTree(Files.readAllBytes(effectiveConfig));
-                DEFAULT_NUCLEUS_VERSION = config.get("services").get("aws.greengrass.Nucleus").get("version").asText();
-                DEFAULT_CORE_THING_NAME = config.get("system").get("thingName").asText();
             }
             return GreengrassContext.builder()
                     .version(parameterValues.getString(FeatureParameters.NUCLEUS_VERSION)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Fixing an incorrect assumption that the install location is local to host agent
- Test context is now aware of core version, as well as thing name

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
