### PR TITLE
fix: use semver release instead of build tag

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
@@ -126,7 +126,7 @@ public class RecipeComponentPreparationService implements ComponentPreparationSe
             Map<String, Object> recipe = mapper.readValue(loader.load(overrideNameVersion.version().value()),
                     new TypeReference<Map<String, Object>>() {});
             recipe.compute(COMPONENT_VERSION, (key, originalValue) -> {
-                return originalValue + "+" + testContext.testId().id();
+                return originalValue + "-" + testContext.testId().id();
             });
             List<Map<String, Object>> manifests = (List<Map<String, Object>>) recipe.get(MANIFESTS);
             for (Map<String, Object> manifest : manifests) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Use the release tag instead of build tag

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
