### PR TITLE
feat: cloud component test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ mvn -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing
 ```
 mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test
 ```
+
+- Run cloud component tests
+```
+mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test
+```
+
 __Debugging test failures__
 
 The test logs path is set using the "test.log.path" property in the project. The default value for this will be

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>aws-greengrass-testing-components</artifactId>
+        <groupId>com.aws.greengrass</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aws-greengrass-testing-components-cloudcomponent</artifactId>
+
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.aws.greengrass.testing.components.cloudcomponent.CloudComponentTest</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>aws-greengrass-testing-features-api</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aws.greengrass</groupId>
+            <artifactId>aws-greengrass-testing-launcher</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.dagger</groupId>
+            <artifactId>dagger</artifactId>
+            <version>2.37</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.dagger</groupId>
+            <artifactId>dagger-compiler</artifactId>
+            <version>2.37</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/CloudComponent.java
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/CloudComponent.java
@@ -1,0 +1,14 @@
+package com.aws.greengrass.testing.components.cloudcomponent;/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import dagger.Component;
+
+import javax.inject.Singleton;
+
+@Component
+@Singleton
+public interface CloudComponent {
+    HelloWorld getHelloWorld();
+}

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/CloudComponentTest.java
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/CloudComponentTest.java
@@ -1,0 +1,22 @@
+package com.aws.greengrass.testing.components.cloudcomponent;/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+public class CloudComponentTest {
+    public static final String COMPONENT_NAME_SYS_PROP = "componentName";
+
+    /**
+     * Main method will call the required com.aws.greengrass.testing.components.cloudcomponent.HelloWorld artifact.
+     *
+     * @param args System Arguments
+     */
+    public static void main(String[] args) {
+        String componentName = System.getProperty(COMPONENT_NAME_SYS_PROP);
+        if (componentName.equals("HelloWorld")) {
+            DaggerCloudComponent.create().getHelloWorld().helloWorld();
+        } else if (componentName.equals("HelloWorldUpdated")) {
+            DaggerCloudComponent.create().getHelloWorld().helloWorldUpdated();
+        }
+    }
+}

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/HelloWorld.java
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/src/main/java/com/aws/greengrass/testing/components/cloudcomponent/HelloWorld.java
@@ -1,0 +1,21 @@
+package com.aws.greengrass.testing.components.cloudcomponent;/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import javax.inject.Inject;
+
+public class HelloWorld {
+
+    @Inject
+    HelloWorld() {
+    }
+
+    public void helloWorld() {
+        System.out.println("Hello World!!");
+    }
+
+    public void helloWorldUpdated() {
+        System.out.println("Hello World Updated!!");
+    }
+}

--- a/aws-greengrass-testing-components/pom.xml
+++ b/aws-greengrass-testing-components/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>aws-greengrass-testing-components-streammanager</module>
         <module>aws-greengrass-testing-components-ggipc</module>
+        <module>aws-greengrass-testing-components-cloudcomponent</module>
     </modules>
 
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>aws-greengrass-testing-features</artifactId>
+        <groupId>com.aws.greengrass</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aws-greengrass-testing-features-cloudcomponent</artifactId>
+
+    <properties>
+        <skipTests>true</skipTests>
+        <components>aws-greengrass-testing-components</components>
+        <component>${components}-cloudcomponent</component>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>aws-greengrass-testing-features-cloudcomponent</finalName>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>download-latest-greengrass</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- download file -->
+                                <get src="https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip"
+                                     dest="${project.basedir}/"
+                                     verbose="false"
+                                     usetimestamp="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>feature-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target>
+                                <echo message="Feature Test Suite"/>
+                                <java classname="com.aws.greengrass.testing.launcher.TestLauncher"
+                                      fork="true"
+                                      failonerror="true"
+                                      newenvironment="true"
+                                      classpathref="maven.test.classpath">
+                                    <sysproperty key="ggc.archive" value="greengrass-nucleus-latest.zip"/>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>aws-greengrass-testing-features-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aws.greengrass</groupId>
+            <artifactId>aws-greengrass-testing-launcher</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aws.greengrass</groupId>
+            <artifactId>${component}</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/assembly/assembly.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/assembly/assembly.xml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/recipes</directory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source> ${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar</source>
+            <outputDirectory>/</outputDirectory>
+            <destName>cloudcomponent.jar</destName>
+        </file>
+    </files>
+</assembly>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/components/recipes/hello_world_recipe.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/components/recipes/hello_world_recipe.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: com.aws.HelloWorld
+ComponentVersion: '1.0.0'
+ComponentDescription: Hello World Cloud Component.
+ComponentPublisher: Amazon
+Manifests:
+  - Artifacts:
+      - URI: file:target/aws-greengrass-testing-features-cloudcomponent.zip
+        Unarchive: ZIP
+        Permission:
+          Read: ALL
+          Execute: ALL
+    Lifecycle:
+      Run: |
+        java -DcomponentName="HelloWorld" -jar {artifacts:decompressedPath}/aws-greengrass-testing-features-cloudcomponent/aws-greengrass-testing-features-cloudcomponent/cloudcomponent.jar

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/components/recipes/hello_world_updated_recipe.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/components/recipes/hello_world_updated_recipe.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: com.aws.HelloWorld
+ComponentVersion: '1.0.1'
+ComponentDescription: Hello World Cloud Component -- Updated Version.
+ComponentPublisher: Amazon
+Manifests:
+  - Artifacts:
+      - URI: file:target/aws-greengrass-testing-features-cloudcomponent.zip
+        Unarchive: ZIP
+        Permission:
+          Read: ALL
+          Execute: ALL
+    Lifecycle:
+      Run: |
+        java -DcomponentName="HelloWorldUpdated" -jar {artifacts:decompressedPath}/aws-greengrass-testing-features-cloudcomponent/aws-greengrass-testing-features-cloudcomponent/cloudcomponent.jar

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/test/resources/greengrass/features/cloudComponent.feature
@@ -1,0 +1,18 @@
+Feature: Testing Cloud component in Greengrass
+
+  Background:
+    Given my device is registered as a Thing
+    And my device is running Greengrass
+
+  Scenario: As a developer, I can create a component in Cloud and deploy it on my device
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World!!" within 20 seconds
+    # Deployment with new version
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_updated_recipe.yaml |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds

--- a/aws-greengrass-testing-features/pom.xml
+++ b/aws-greengrass-testing-features/pom.xml
@@ -18,6 +18,7 @@
         <module>aws-greengrass-testing-features-mqtt</module>
         <module>aws-greengrass-testing-features-streammanager</module>
         <module>aws-greengrass-testing-features-docker</module>
+        <module>aws-greengrass-testing-features-cloudcomponent</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add Cloud component tests for IDT to this framework

Refactor to run the tests from feature module

Why is this change necessary:


How was this change tested:
Ran the cloud tests using following command:
mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test

Any additional information or context required to review the change:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
