### PR TITLE
fix: update standalone jar to include all artifacts

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
@@ -40,9 +40,44 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>greengrass/features/cloudComponent.feature</include>
+                                    <include>greengrass/components/artifacts/${project.artifactId}.zip</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
+                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
+                    <execution>
+                        <id>copy-artifact-to-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target name="copy mqtt component zip file">
+                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
+                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/${project.artifactId}.zip"/>
+                            </target>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe.yaml
@@ -11,7 +11,7 @@ ComponentDescription: Hello World Cloud Component.
 ComponentPublisher: Amazon
 Manifests:
   - Artifacts:
-      - URI: file:target/aws-greengrass-testing-features-cloudcomponent.zip
+      - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-cloudcomponent.zip
         Unarchive: ZIP
         Permission:
           Read: ALL

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
@@ -21,18 +21,41 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>greengrass/features/cloudComponent.feature</include>
+                                    <include>greengrass/components/artifacts/cloudcomponent*</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
+                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
                     <execution>
-                        <id>copy-cloud-component-artifact</id>
-                        <phase>prepare-package</phase>
+                        <id>copy-artifact-to-resources</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <target name="copy cloud component jar file">
-                                <copy file="${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar" tofile="${project.basedir}/target/cloudcomponent.jar"/>
+                                <copy file="${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar"
+                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/cloudcomponent.jar"/>
                             </target>
                         </configuration>
                     </execution>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world.yaml
@@ -11,8 +11,7 @@ ComponentDescription: Hello World local Component.
 ComponentPublisher: Amazon
 Manifests:
   - Artifacts:
-      - URI: file:target/cloudcomponent.jar
-        Unarchive: ZIP
+      - URI: classpath:/greengrass/components/artifacts/cloudcomponent.jar
         Permission:
           Read: ALL
           Execute: ALL

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -12,7 +12,7 @@ Feature: Testing local deployment using CLI in Greengrass
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     Then I verify greengrass-cli is available in greengrass root
     When I create a local deployment with components
-      | aws.greengrass.LocalHelloWorld | local:localcomponent/recipes/local_hello_world.yaml |
+      | aws.greengrass.LocalHelloWorld | local:/greengrass/components/recipes/local_hello_world.yaml |
     Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
     And the aws.greengrass.LocalHelloWorld log on the device contains the line "Hello World!!" within 20 seconds
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
@@ -16,7 +16,6 @@
         <components>aws-greengrass-testing-components</components>
         <component>${components}-ggipc</component>
     </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -40,9 +39,44 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>greengrass/features/mqtt.feature</include>
+                                    <include>greengrass/components/artifacts/*.zip</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
+                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
+                    <execution>
+                        <id>copy-artifact-to-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target name="copy mqtt component zip file">
+                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
+                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/${project.artifactId}.zip"/>
+                            </target>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/components/recipes/iot_mqtt_publisher.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/components/recipes/iot_mqtt_publisher.yaml
@@ -28,7 +28,7 @@ ComponentConfiguration:
             - "*"
 Manifests:
   - Artifacts:
-      - URI: file:target/aws-greengrass-testing-features-mqtt.zip
+      - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-mqtt.zip
         Unarchive: ZIP
         Permission:
           Read: ALL

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/components/recipes/iot_mqtt_subscriber.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/components/recipes/iot_mqtt_subscriber.yaml
@@ -25,7 +25,7 @@ ComponentConfiguration:
 
 Manifests:
   - Artifacts:
-      - URI: file:target/aws-greengrass-testing-features-mqtt.zip
+      - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-mqtt.zip
         Unarchive: ZIP
         Permission:
           Read: ALL


### PR DESCRIPTION
**Issue #, if available:**
The standalone jar created for use in the IDT did not contain certain artifacts like the cloudcomponent.jar, mqtt.zip since these were not put into the resource folder. 

**Description of changes:**
These changes update the recipes to use classpath instead of file modifier so the same recipe can work in IDT setup where files are looked up in classpath which includes files from the uber jar. 
These changes also put the missing artifacts in the standalone jar.

**Why is this change necessary:**
For IDT to successfully runt the tests in their pipeline. 

**How was this change tested:**
Ran the tests locally. Verified that standalone jar has the expected artifacts.

**Any additional information or context required to review the change:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
