### PR TITLE
fix: include artifacts in standalone jar

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
@@ -55,6 +55,12 @@
                                     <include>greengrass/components/artifacts/${project.artifactId}.zip</include>
                                 </includes>
                             </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>greengrass/components/artifacts/${project.artifactId}.zip</resource>
+                                    <file>${project.basedir}/target/${project.artifactId}.zip</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>
@@ -64,20 +70,6 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
-                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
-                    <execution>
-                        <id>copy-artifact-to-resources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="copy mqtt component zip file">
-                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
-                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/${project.artifactId}.zip"/>
-                            </target>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
@@ -36,6 +36,12 @@
                                     <include>greengrass/components/artifacts/cloudcomponent*</include>
                                 </includes>
                             </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>greengrass/components/artifacts/cloudcomponent.jar</resource>
+                                    <file>${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>
@@ -45,20 +51,6 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
-                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
-                    <execution>
-                        <id>copy-artifact-to-resources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="copy cloud component jar file">
-                                <copy file="${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar"
-                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/cloudcomponent.jar"/>
-                            </target>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
@@ -23,7 +23,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
@@ -39,44 +39,9 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>greengrass/features/mqtt.feature</include>
-                                    <include>greengrass/components/artifacts/*.zip</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
-                    <!-- Adding it here and not in shade plugin transform so it is included in classpath for local run-->
-                    <execution>
-                        <id>copy-artifact-to-resources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="copy mqtt component zip file">
-                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
-                                      tofile="${project.basedir}/src/main/resources/greengrass/components/artifacts/${project.artifactId}.zip"/>
-                            </target>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>
@@ -111,6 +76,33 @@
                                     <sysproperty key="ggc.archive" value="greengrass-nucleus-latest.zip"/>
                                 </java>
                             </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>greengrass/features/mqtt.feature</include>
+                                    <include>greengrass/components/artifacts/${project.artifactId}.zip</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>greengrass/components/artifacts/${project.artifactId}.zip</resource>
+                                    <file>${project.basedir}/target/${project.artifactId}.zip</file>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
**Issue #, if available:**
Artifacts for mqtt, cloudcomponent, and local deployment are not getting included in the standalone jar. 

**Description of changes:**
These changes include the artifacts, but running the test fails locally as artifacts are not found on classpath. I will be working on fixing that. But this is to unblock IDT release. 

**Why is this change necessary:**
It is blocking IDT testing

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
