### PR TITLE
fix: add artifacts to classpath for local testing

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
@@ -71,6 +71,20 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
+                        <id>copy-artifact-to-classpath</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target name="copy mqtt component zip file">
+                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
+                                      tofile="${project.basedir}/target/classes/greengrass/components/artifacts/${project.artifactId}.zip"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
@@ -52,6 +52,20 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
+                        <id>copy-artifact-to-classpath</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target name="copy cloud component jar file">
+                                <copy file="${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar"
+                                      tofile="${project.basedir}/target/classes/greengrass/components/artifacts/cloudcomponent.jar"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>
                         <goals>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
@@ -23,7 +23,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>prepare-package</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
@@ -42,6 +42,20 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
+                    <execution>
+                        <id>copy-artifact-to-classpath</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <target name="copy mqtt component zip file">
+                                <copy file="${project.basedir}/target/${project.artifactId}.zip"
+                                      tofile="${project.basedir}/target/classes/greengrass/components/artifacts/${project.artifactId}.zip"/>
+                            </target>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>download-latest-greengrass</id>
                         <phase>prepare-package</phase>
@@ -68,6 +82,7 @@
                             <skip>${skipTests}</skip>
                             <target>
                                 <echo message="Feature Test Suite"/>
+
                                 <java classname="com.aws.greengrass.testing.launcher.TestLauncher"
                                       fork="true"
                                       failonerror="true"
@@ -108,6 +123,12 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/main/resources/greengrass/components/artifacts/</directory>
+            </testResource>
+        </testResources>
     </build>
 
     <dependencies>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/assembly/assembly.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/assembly/assembly.xml
@@ -13,11 +13,6 @@
     <formats>
         <format>zip</format>
     </formats>
-    <fileSets>
-        <fileSet>
-            <directory>${project.basedir}/recipes</directory>
-        </fileSet>
-    </fileSets>
     <files>
         <file>
             <source> ${project.basedir}/../../${components}/${component}/target/${component}-${project.parent.version}.jar</source>


### PR DESCRIPTION
**Issue #, if available:**
Packing artifacts into the shaded jar does not include them in the test classpath when run the integration tests locally. This results in failure of integ tests when run locally

**Description of changes:**
This change adds the artifacts into test classpath. 

**Why is this change necessary:**
To make the development in this package smooth.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
