### PR TITLE
fix: a few notices from a recent audit

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
@@ -78,17 +78,18 @@ public class RecipeComponentPreparationService implements ComponentPreparationSe
         // TODO: make this an extension point
         switch (parts[0]) {
             case "classpath":
-                InputStream content = Objects.requireNonNull(getClass().getResourceAsStream(parts[1]),
-                        "Not found on classpath: " + parts[1]);
-                Path contentPath = Paths.get(parts[1]);
-                componentArtifact = greengrassContext.tempDirectory()
-                        .resolve(testContext.testId().id())
-                        .resolve("components")
-                        .resolve(componentName);
-                Files.createDirectories(componentArtifact);
-                componentArtifact = componentArtifact.resolve(contentPath.getFileName());
-                try (FileOutputStream fos = new FileOutputStream(componentArtifact.toFile())) {
-                    IoUtils.copy(content, fos);
+                try (InputStream content = Objects.requireNonNull(getClass().getResourceAsStream(parts[1]),
+                        "Not found on classpath: " + parts[1])) {
+                    Path contentPath = Paths.get(parts[1]);
+                    componentArtifact = greengrassContext.tempDirectory()
+                            .resolve(testContext.testId().id())
+                            .resolve("components")
+                            .resolve(componentName);
+                    Files.createDirectories(componentArtifact);
+                    componentArtifact = componentArtifact.resolve(contentPath.getFileName());
+                    try (FileOutputStream fos = new FileOutputStream(componentArtifact.toFile())) {
+                        IoUtils.copy(content, fos);
+                    }
                 }
                 break;
             case "file":

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.inject.Inject;
@@ -38,6 +38,7 @@ public class FileSteps {
     private final TestContext testContext;
     private final ScenarioContext scenarioContext;
     private final WaitSteps waits;
+    private final SecureRandom random;
 
     private enum ByteNotation implements Function<Long, Long> {
         B(1),
@@ -67,6 +68,8 @@ public class FileSteps {
         this.testContext = testContext;
         this.scenarioContext = scenarioContext;
         this.waits = waits;
+        this.random = new SecureRandom();
+        random.setSeed(System.currentTimeMillis());
     }
 
     /**
@@ -157,7 +160,6 @@ public class FileSteps {
         if (Files.exists(filePath)) {
             throw new IllegalStateException("The file " + filePath + " already exists");
         }
-        Random random = new Random();
         try (BufferedWriter writer = Files.newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
             random.ints(0, 127).limit(notation.apply(length)).forEach(singleByte -> {
                 try {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -47,6 +47,11 @@ public class GreengrassContextModule extends AbstractModule {
             ZipEntry entry = zipStream.getNextEntry();
             while (Objects.nonNull(entry)) {
                 final Path contentPath = stagingPath.resolve(entry.getName());
+                if (!contentPath.toFile().getCanonicalPath().startsWith(stagingPath.toString())) {
+                    LOGGER.warn("Archive attempted to write {} outside of {}, skipping",
+                            contentPath, stagingPath);
+                    continue;
+                }
                 if (entry.isDirectory()) {
                     Files.createDirectories(contentPath);
                     entry = zipStream.getNextEntry();

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/PlatformFiles.java
@@ -34,26 +34,4 @@ public interface PlatformFiles {
     boolean exists(Path filePath) throws CommandExecutionException;
 
     String format(Path filePath);
-
-    /**
-     * Perform a recursive copy from remote source to local destination.
-     *
-     * @param source Remote {@link Path} to copy from the device
-     * @param destination Local {@link Path} to copy to the host
-     * @throws CopyException Any propagated local nio utility IOException
-     * @throws CommandExecutionException Any remote execution failing as a command exception
-     */
-    default void copyFrom(Path source, Path destination) throws CopyException, CommandExecutionException {
-        final Path destinationRoot = destination.resolve(source.getFileName());
-        try {
-            Files.createDirectories(destinationRoot);
-            for (Path file : listContents(source)) {
-                final Path destinationFile = destination.resolve(file);
-                Files.createDirectories(destinationFile.getParent());
-                Files.write(destinationFile, readBytes(file));
-            }
-        } catch (IOException ie) {
-            throw new CopyException(ie, source, destination);
-        }
-    }
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixing the critical and highs found on a recent Fortify scan.

**Description of changes:**

- Closing the archive path
- SecureRandom in the random file generated
- Properly closing streams in the recipe converter
- Dropping one unused method in the `PlatformFiles` interface

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
