### PR TITLE
fix: bug fix cloud and local deployment idt tests

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_updated_recipe.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_updated_recipe.yaml
@@ -11,7 +11,7 @@ ComponentDescription: Hello World Cloud Component -- Updated Version.
 ComponentPublisher: Amazon
 Manifests:
   - Artifacts:
-      - URI: file:target/aws-greengrass-testing-features-cloudcomponent.zip
+      - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-cloudcomponent.zip
         Unarchive: ZIP
         Permission:
           Read: ALL

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixFiles.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.testing.api.device.exception.CopyException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.device.model.PlatformOS;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -87,7 +88,7 @@ public abstract class UnixFiles implements PlatformFiles, UnixPathsMixin {
     public void writeBytes(Path filePath, byte[] bytes) {
         commands.execute(CommandInput.builder()
                 .line("echo ")
-                .addArgs(String.format("'%s'",bytes.toString()), " > ", filePath.toString())
+                .addArgs(String.format("'%s'",new String(bytes, StandardCharsets.UTF_8)), " > ", filePath.toString())
                 .build());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Cloud deployment failed because recipe did not had the correct artifact path
Local deployment failed due to a bug in UnixFiles writeBytes method

**Description of changes:**
Fixes for above issue.

**Why is this change necessary:**
For IDT release

**How was this change tested:**
Tested by running both the tests in personal IDT setup.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
