### PR TITLE
fix: extraction loop if extracting outside

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -47,9 +47,10 @@ public class GreengrassContextModule extends AbstractModule {
             ZipEntry entry = zipStream.getNextEntry();
             while (Objects.nonNull(entry)) {
                 final Path contentPath = stagingPath.resolve(entry.getName());
-                if (!contentPath.toFile().getCanonicalPath().startsWith(stagingPath.toString())) {
+                if (!contentPath.toFile().getCanonicalPath().startsWith(stagingPath.toAbsolutePath().toString())) {
                     LOGGER.warn("Archive attempted to write {} outside of {}, skipping",
                             contentPath, stagingPath);
+                    entry = zipStream.getNextEntry();
                     continue;
                 }
                 if (entry.isDirectory()) {


### PR DESCRIPTION
**Issue #, if available:**

If the path to extract from the zip resolved outside of the staging area, then it would result in an infinite loop.

**Description of changes:**

The fix is to progress the zip entry in those cases, thus moving forward with the extraction.

**Why is this change necessary:**

**How was this change tested:**

```
mvn clean -DskipTests=false -pl aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager -am integration-test
```
Passed

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
