### PR TITLE
fix: fix window cmds to run on dut

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
@@ -27,8 +27,8 @@ public abstract class AbstractRemoteDevice implements Device {
         try {
             execute(CommandInput.builder()
                     .line("java")
-                    .addArgs("-jar", pillboxContext.onDevice().toString())
-                    .addArgs("files", "exists", path)
+                    .addArgs("-jar", pillboxContext.onDevice().toString(),
+                            "files", "exists", path)
                     .build());  
             return true;
         } catch (CommandExecutionException e) {
@@ -42,8 +42,8 @@ public abstract class AbstractRemoteDevice implements Device {
         // Eject the binary on the device upon closure
         execute(CommandInput.builder()
                 .line("java")
-                .addArgs("-jar", pillboxContext.onDevice().toString())
-                .addArgs("files", "rm", pillboxContext.onDevice().toString())
+                .addArgs("-jar", pillboxContext.onDevice().toString(),
+                        "files", "rm", pillboxContext.onDevice().toString())
                 .build());
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -7,7 +7,7 @@ Feature: Testing local deployment using CLI in Greengrass
   @LocalDeployment @IDT
   Scenario: A component is deployed locally using CLI
     When I create a Greengrass deployment with components
-      | aws.greengrass.Cli | 2.4.0 |
+      | aws.greengrass.Cli | LATEST |
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     Then I verify greengrass-cli is available in greengrass root

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
@@ -33,8 +33,8 @@ public class WindowsCommands implements Commands {
         final StringJoiner joiner = new StringJoiner(" ").add(input.line());
         Optional.ofNullable(input.args()).ifPresent(args -> args.forEach(joiner::add));
         return device.execute(CommandInput.builder()
-                .line("cmd.exe")
-                .addArgs("/c", joiner.toString())
+                .line("cmd.exe /c")
+                .addArgs(joiner.toString())
                 .input(input.input())
                 .timeout(input.timeout())
                 .build());


### PR DESCRIPTION
Issue #, if available:
Windows Commands get appended with qoutes with arg "/c" letting it fail.
Also, updated local deployment features file.

Description of changes:
Moved "/c" form args to line() with cmd.exe

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
