### PR TITLE
feat: add iam role as feature parameter

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/model/TestContextModel.java
@@ -41,6 +41,8 @@ interface TestContextModel extends Closeable {
 
     String coreVersion();
 
+    String tesRoleName();
+
     @Override
     default void close() throws IOException {
         if (!cleanupContext().persistGeneratedFiles()) {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/FeatureParameters.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/FeatureParameters.java
@@ -25,6 +25,7 @@ public class FeatureParameters implements Parameters {
     static final String TEST_TEMP_PATH = "test.temp.path";
     static final String TEST_RESULTS_PATH = "test.log.path";
     static final String TEST_ID_PREFIX = "test.id.prefix";
+    static final String TES_ROLE_NAME = "ggc.tes.rolename";
 
     @Override
     public List<Parameter> available() {
@@ -48,7 +49,10 @@ public class FeatureParameters implements Parameters {
                 Parameter.of(TEST_RESULTS_PATH, "Directory that will contain the results of the "
                         + "entire test run. Defaults to \"testResults\"."),
                 Parameter.of(TEST_ID_PREFIX, "A common prefix applied to all test specific resources "
-                        + "including AWS resource names and tags. Default is a \"gg\" prefix.")
+                        + "including AWS resource names and tags. Default is a \"gg\" prefix."),
+                Parameter.of(TES_ROLE_NAME, "The Iam Role that ggc will assume to access AWS services"
+                        + "If a role with given name does not exist then one will be created and default access "
+                        + "policy")
         );
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/TestContextModule.java
@@ -109,6 +109,7 @@ public class TestContextModule extends AbstractModule {
                 .coreThingName(coreThingName)
                 .coreVersion(coreVersion)
                 .initializationContext(initializationContext)
+                .tesRoleName(parameterValues.getString(FeatureParameters.TES_ROLE_NAME).orElse(""))
                 .build();
     }
 }

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamLifecycle.java
@@ -10,7 +10,11 @@ import com.aws.greengrass.testing.resources.AWSResourceLifecycle;
 import com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle;
 import com.google.auto.service.AutoService;
 import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.GetRoleRequest;
+import software.amazon.awssdk.services.iam.model.GetRoleResponse;
+import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
 
+import java.util.Optional;
 import javax.inject.Inject;
 
 @AutoService(AWSResourceLifecycle.class)
@@ -22,5 +26,22 @@ public class IamLifecycle extends AbstractAWSResourceLifecycle<IamClient> {
 
     public IamLifecycle() {
         this(IamClient.builder().build());
+    }
+
+    /**
+     * Get the IamRole for given name.
+     * @param iamRoleName role name
+     * @return {@link IamRole}
+     */
+    public Optional<IamRole> getIamRole(String iamRoleName) {
+        try {
+            GetRoleResponse response = this.client.getRole(GetRoleRequest.builder().roleName(iamRoleName).build());
+            return Optional.of(IamRole.builder()
+                    .roleName(response.role().roleName())
+                    .roleArn(response.role().arn())
+                    .build());
+        } catch (NoSuchEntityException e) {
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Feature request to add IAM role as a parameter for test configuration. The role will be used as TES role by Greengrass.

**Description of changes:**
Added the parameter

**Why is this change necessary:**
Feature request from IDT, needed for IDT customer ARM. 

**How was this change tested:**
Tested locally with setting this property
<sysproperty key="ggc.tes.iamrolename" value="idtCustomIamRole"/>
 in the cloudcomponent test. Used it with my personal account where I created the role using documentation at https://docs.aws.amazon.com/greengrass/v2/developerguide/manual-installation.html#create-token-exchange-role

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
