### PR TITLE
fix: descendants of greengrass process

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
@@ -40,10 +40,18 @@ public abstract class AbstractRemoteDevice implements Device {
     @Override
     public void close() throws IOException {
         // Eject the binary on the device upon closure
-        execute(CommandInput.builder()
-                .line("java")
-                .addArgs("-jar", pillboxContext.onDevice().toString(),
-                        "files", "rm", pillboxContext.onDevice().toString())
-                .build());
+        // Window OS doesn't support deleting file using itself. Thus window command "del" is used for cleanup.
+        if (platform().isWindows()) {
+            execute(CommandInput.builder()
+                    .line("cmd.exe /c")
+                    .addArgs("del " +  pillboxContext.onDevice().toString())
+                    .build());
+        } else {
+            execute(CommandInput.builder()
+                    .line("java")
+                    .addArgs("-jar", pillboxContext.onDevice().toString(),
+                            "files", "rm", pillboxContext.onDevice().toString())
+                    .build());
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
1. Pillbox jar was not able to kill itself.
2. Orphan process remain on DUT after killing Greengrass process.

**Description of changes:**
1. Instead of using pillbox jar used windows command to remove it from DUT.
2. Using wmic get a list of all child processes of Greengrass and kill them during cleanup.

**Why is this change necessary:**
This change was necessary for successful resource cleanup after test run.

**How was this change tested:**
Tested successfully on local as well remote windows DUT.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
