### PR TITLE
fix: use canoncial for staging and content

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/GreengrassContextModule.java
@@ -47,9 +47,11 @@ public class GreengrassContextModule extends AbstractModule {
             ZipEntry entry = zipStream.getNextEntry();
             while (Objects.nonNull(entry)) {
                 final Path contentPath = stagingPath.resolve(entry.getName());
-                if (!contentPath.toFile().getAbsolutePath().startsWith(stagingPath.toAbsolutePath().toString())) {
+                final String contentCanonical = contentPath.toFile().getCanonicalPath();
+                final String stagingCanonical = stagingPath.toFile().getCanonicalPath();
+                if (!contentCanonical.startsWith(stagingCanonical)) {
                     LOGGER.warn("Archive attempted to write {} outside of {}, skipping",
-                            contentPath.toFile().getAbsolutePath(), stagingPath.toAbsolutePath());
+                            contentCanonical, stagingCanonical);
                     entry = zipStream.getNextEntry();
                     continue;
                 }


### PR DESCRIPTION
**Issue #, if available:**

Fortify caught this code path again.

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

- StreamManager test locally

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
