### PR TITLE
fix: use correct paths for copying recipe and artifacts

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/LocalComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/LocalComponentPreparationService.java
@@ -137,8 +137,8 @@ public class LocalComponentPreparationService implements ComponentPreparationSer
     }
 
     private void copyArtifactToLocalStore(Path artifactFilePath, String componentName, String componentVersion) {
-        Path localStoreArtifactPath = testContext.installRoot().resolve(LOCAL_STORE).resolve(ARTIFACTS_DIR);
-        Path componentArtifactPath = localStoreArtifactPath.resolve(componentName).resolve(componentVersion);
+        Path localStoreArtifactPathOnDevice = testContext.installRoot().resolve(LOCAL_STORE).resolve(ARTIFACTS_DIR);
+        Path componentArtifactPath = localStoreArtifactPathOnDevice.resolve(componentName).resolve(componentVersion);
 
         platform.files().makeDirectories(componentArtifactPath);
         platform.files().copyTo(artifactFilePath, componentArtifactPath.resolve(artifactFilePath.getFileName()));
@@ -146,11 +146,14 @@ public class LocalComponentPreparationService implements ComponentPreparationSer
 
     private void copyRecipeToLocalStore(String recipe, String componentName, String componentVersion)
             throws IOException {
-        Path localStoreRecipePath = testContext.installRoot().resolve(LOCAL_STORE).resolve(RECIPE_DIR);
-        Files.createDirectories(localStoreRecipePath);
+        Path hostPath = testContext.testDirectory().resolve(LOCAL_STORE).resolve(RECIPE_DIR);
+        Files.createDirectories(hostPath);
         // TODO: Add conditional for json as well
-        Path componentRecipePath = localStoreRecipePath.resolve(componentName + "-" + componentVersion + ".yaml");
+        Path componentRecipePath = hostPath.resolve(componentName + "-" + componentVersion + ".yaml");
         Files.write(componentRecipePath, recipe.getBytes(StandardCharsets.UTF_8));
-        platform.files().copyTo(localStoreRecipePath, localStoreRecipePath);
+        Path localStoreRecipePathOnDevice = testContext.installRoot().resolve(LOCAL_STORE).resolve(RECIPE_DIR);
+        platform.files().makeDirectories(localStoreRecipePathOnDevice);
+        platform.files().copyTo(componentRecipePath, localStoreRecipePathOnDevice
+                .resolve(componentName + "-" + componentVersion + ".yaml"));
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
The paths for copying local artifacts were messed up.

**Description of changes:**
Paths for copying artifacts and recipe is fixed. 

**Why is this change necessary:**

**How was this change tested:**
Ran E2E test on linux device for local deployment, cloud and mqtt.
Ran E2E test on windows device for local deployment, cloud and mqtt.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
