### PR TITLE
fix: update log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- Dependency versions -->
         <cucumber.version>5.7.0</cucumber.version>
         <immutables.version>2.8.2</immutables.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <aws.sdk.version>2.16.52</aws.sdk.version>
         <auto.service.version>1.0</auto.service.version>
         <findbugs.version>3.0.2</findbugs.version>


### PR DESCRIPTION
**Issue #, if available:**
Second fix for log4j is release in new version 2.16.0

**Description of changes:**
Updating the log4j version

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
