### PR TITLE
fix: add gg policy to existing cert and detach policy before deleting

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
@@ -15,6 +15,7 @@ import io.cucumber.java.en.Given;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotPolicyModel.java
@@ -10,6 +10,10 @@ import com.aws.greengrass.testing.resources.AWSResource;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.DeletePolicyRequest;
+import software.amazon.awssdk.services.iot.model.DetachPolicyRequest;
+import software.amazon.awssdk.services.iot.model.ListTargetsForPolicyRequest;
+
+import java.util.List;
 
 @TestingModel
 @Value.Immutable
@@ -20,6 +24,19 @@ interface IotPolicyModel extends AWSResource<IotClient> {
 
     @Override
     default void remove(IotClient client) {
+        List<String> targets =
+                client.listTargetsForPolicy(ListTargetsForPolicyRequest.builder()
+                        .policyName(policyName())
+                        .build())
+                        .targets();
+        if (targets != null) {
+            for (String target : targets) {
+                client.detachPolicy(DetachPolicyRequest.builder()
+                        .target(target)
+                        .policyName(policyName())
+                        .build());
+            }
+        }
         client.deletePolicy(DeletePolicyRequest.builder()
                 .policyName(policyName())
                 .build());

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingModel.java
@@ -39,6 +39,7 @@ interface IotThingModel extends AWSResource<IotClient> {
                             .principal(p)
                             .build());
                 });
+
         client.deleteThing(DeleteThingRequest.builder()
                 .thingName(thingName())
                 .build());

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 @TestingModel
 @Value.Immutable
 interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing>, IotTaggingMixin {
+
     @Nullable
     Set<IotThingGroupSpec> thingGroups();
 
@@ -78,6 +79,12 @@ interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing>, IotTaggin
                     .principal(certificateSpec().existingArn())
                     .build());
             certificateArn = certificateSpec().existingArn();
+            if (policySpec() != null) {
+                client.attachPolicy(AttachPolicyRequest.builder()
+                        .policyName(policySpec().policyName())
+                        .target(certificateArn)
+                        .build());
+            }
         }
 
         if (assumeRolePolicy != null) {


### PR DESCRIPTION
**Issue #, if available:**
IDT expects OTF to create the GG iot thing policy for the given existing certificate. 
The policies attached to given cert cannot be deleted as they were not being detached from the cert 
**Description of changes:**
These changes attaches the ggv2 iot thing policy to the cert as part of the test run and detach the policy from the given cert when the test finishes.

**Why is this change necessary:**

**How was this change tested:**
Tested with a soft HSM enabled linux device using IDT setup. Verified that the policies are created, attached and detached.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
