### PR TITLE
feat: add support for custom root CA

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/HsmParameters.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/HsmParameters.java
@@ -19,7 +19,7 @@ public class HsmParameters implements Parameters {
     public static final String SLOT_USER_PIN = "ggc.hsm.slotUserPin";
     public static final String SLOT_LABEL = "ggc.hsm.slotLabel";
     public static final String HSM_CERT_AND_KEY_LABEL = "ggc.hsm.certandkey.label";
-
+    public static final String ROOT_CA_PATH = "ggc.rootCA.path";
 
     @Override
     public List<Parameter> available() {
@@ -31,7 +31,9 @@ public class HsmParameters implements Parameters {
                 Parameter.of(SLOT_ID, "HSM slot Id"),
                 Parameter.of(SLOT_USER_PIN, "HSM slot user pin"),
                 Parameter.of(SLOT_LABEL, "HSM Slot label"),
-                Parameter.of(HSM_CERT_AND_KEY_LABEL, "The label for the private key and certificate in hsm")
+                Parameter.of(HSM_CERT_AND_KEY_LABEL, "The label for the private key and certificate in hsm"),
+                Parameter.of(ROOT_CA_PATH, "The path of the root CA that should be used with the device"
+                        + "certificate. By default AmazonRootCA will be used")
         );
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
IDT requires parameter for passing a custom root CA for their HSM tests. 

**Description of changes:**
If the rootCA path is passed, then rootCA is used from that path.

**Why is this change necessary:**
Required for IDT customers to be able to use custom root CA for the certs in their HSM.

**How was this change tested:**
The parameter was tested by passing the Amazon root CA at a given path and run the mqtt tests. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
