### PR TITLE
fix: enable to check if resources available in cloud after creation

### DIFF
--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/AbstractAWSResourceLifecycle.java
@@ -8,16 +8,24 @@ package com.aws.greengrass.testing.resources;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLifecycle<C> {
     private static final Logger LOGGER = LogManager.getLogger(AbstractAWSResourceLifecycle.class);
+    private static final long MAX_WAIT_TIME_FOR_CLOUD_OPERATION = 5;
     protected C client;
     protected List<Class<? extends ResourceSpec<C, ? extends AWSResource<C>>>> specClasses;
     protected List<ResourceSpec<C, ? extends AWSResource<C>>> specs;
@@ -45,6 +53,30 @@ public abstract class AbstractAWSResourceLifecycle<C> implements AWSResourceLife
             return spec;
         }
         ResourceSpec<C,R> update = spec.create(client, resources);
+        // check if the resource is available in cloud
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future future = executor.submit(() -> {
+            while (!update.availableInCloud(client)) {
+                try {
+                    Thread.sleep(Duration.ofSeconds(1).toMillis());
+                } catch (InterruptedException e) {
+                    LOGGER.warn("Interrupted while waiting for resource to get created in cloud");
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+
+        try {
+            future.get(MAX_WAIT_TIME_FOR_CLOUD_OPERATION, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOGGER.warn("Interrupted while checking if the resource is created in cloud. Resource type: {}",
+                    spec.getClass().getSimpleName());
+        } catch (ExecutionException | TimeoutException e) {
+            LOGGER.warn("Check for resources created in cloud failed. Resource type: {}. Moving on",
+                    spec.getClass().getSimpleName());
+        }
+
         // Prepend so as to reverse the deletion
         specs.add(0, update);
         LOGGER.info("Created {} in {}", update.resource().getClass().getSimpleName(), displayName());

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceSpec.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/src/main/java/com/aws/greengrass/testing/resources/ResourceSpec.java
@@ -12,6 +12,10 @@ import javax.annotation.Nullable;
 public interface ResourceSpec<C, T extends AWSResource<C>> {
     ResourceSpec<C, T> create(C client, AWSResources resources);
 
+    default boolean availableInCloud(C client) {
+        return created();
+    }
+
     @Nullable
     T resource();
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/src/main/java/com/aws/greengrass/testing/resources/iam/IamRoleSpecModel.java
@@ -7,13 +7,19 @@ package com.aws.greengrass.testing.resources.iam;
 
 import com.aws.greengrass.testing.api.model.TestingModel;
 import com.aws.greengrass.testing.resources.AWSResources;
+import com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle;
 import com.aws.greengrass.testing.resources.ResourceSpec;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.AttachRolePolicyRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
 import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
+import software.amazon.awssdk.services.iam.model.GetRoleRequest;
+import software.amazon.awssdk.services.iam.model.GetRoleResponse;
+import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
 
 import javax.annotation.Nullable;
 
@@ -60,4 +66,14 @@ interface IamRoleSpecModel extends ResourceSpec<IamClient, IamRole>, IamTaggingM
 
     @Nullable
     IamRole resource();
+
+    @Override
+    default boolean availableInCloud(IamClient client) {
+        try {
+            client.getRole(GetRoleRequest.builder().roleName(roleName()).build());
+        } catch (NoSuchEntityException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotRoleAliasSpecModel.java
@@ -13,6 +13,8 @@ import org.immutables.value.Value;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateRoleAliasRequest;
 import software.amazon.awssdk.services.iot.model.CreateRoleAliasResponse;
+import software.amazon.awssdk.services.iot.model.DescribeRoleAliasRequest;
+import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +40,18 @@ interface IotRoleAliasSpecModel extends ResourceSpec<IotClient, IotRoleAlias>, I
                         .roleAliasArn(createdAlias.roleAliasArn())
                         .build())
                 .build();
+    }
+
+    @Override
+    default boolean availableInCloud(IotClient client) {
+        try {
+            client.describeRoleAlias(DescribeRoleAliasRequest.builder()
+                    .roleAlias(name())
+                    .build());
+        } catch (ResourceNotFoundException e) {
+            return false;
+        }
+        return true;
     }
 
     @Nullable


### PR DESCRIPTION
**Issue #, if available:**
P58338530

The issue reported in ticket indicates that role alias is being accessed before its creation is complete in cloud. 

**Description of changes:**
These changes allow to add a check for resource spec to verify the availability of resource in cloud. 

**Why is this change necessary:**
To make the test runs more robust. 

**How was this change tested:**
I ran mqtt tests locally, verifying that the check for IamRole and IotRoleAlias are triggered. The tests pass successfully. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
