### PR TITLE
fix: Propagate Device CommandExecutionException as a warning

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
@@ -32,7 +32,7 @@ public abstract class AbstractRemoteDevice implements Device {
                     .build());  
             return true;
         } catch (CommandExecutionException e) {
-            LOGGER.debug("Failed to check if path {} exists, assuming false", path, e);
+            LOGGER.warn("Failed to check if path {} exists, assuming false", path, e);
             return false;
         }
     }


### PR DESCRIPTION
**Issue #, if available:**
https://t.corp.amazon.com/P58672990
When `java` isn't installed on the DUT, Test run fails with `PlatformResolutionException: Could not find a platform support for device: PlatformOS{name=Linux, arch=armv7l}` instead of exposing the actual `CommandExecutionException` with the message  `sudo: java: command not found`  

**Description of changes:**
Changing the debug message to warning to surface the CommandExecutionException in the test run log

**Why is this change necessary:**
To enable easy debugging. 

**How was this change tested:**
Ran the component tests to verify that the warning message is visible in the test run output.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
