### PR TITLE
fix: handle command execution exception

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
@@ -33,7 +33,7 @@ public abstract class AbstractRemoteDevice implements Device {
                     .build());
             if (output.trim().equals("false")) {
                 LOGGER.info("File {} does not exists", path);
-            } else if (output.isEmpty()) {
+            } else if (output.trim().equals("true")) {
                 LOGGER.info("File {} exists", path);
                 existFlag = true;
             }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/RemoteFiles.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/RemoteFiles.java
@@ -83,7 +83,7 @@ public class RemoteFiles implements PlatformFiles, UnixPathsMixin {
         boolean existFlag = false;
         try {
             byte[] output = files("exists", format(filePath));
-            if (new String(output).isEmpty()) {
+            if (new String(output).trim().equals("true")) {
                 existFlag = true;
             }
             return existFlag;

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Cat.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Cat.java
@@ -26,13 +26,13 @@ public class Cat implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         Path filePath = Paths.get(file);
-        int exitCode = Exists.call(filePath);
-        if (exitCode > 0) {
-            return exitCode;
+        if (Files.notExists(filePath)) {
+            System.out.println("File " + filePath + " does not exists");
+            return 0;
         }
         if (!Files.isRegularFile(filePath)) {
-            System.out.println("File '" + filePath + "' is not a file.");
-            return 0;
+            System.err.println("File '" + filePath + "' is not a file.");
+            return 1;
         }
         final byte[] buffer = new byte[BUFFER];
         try (InputStream input = new BufferedInputStream(Files.newInputStream(filePath))) {

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Exists.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Exists.java
@@ -23,6 +23,7 @@ public class Exists implements Callable<Integer> {
         if (Files.notExists(filePath)) {
             System.out.println("false");
         }
+        System.out.println("true");
         return 0;
     }
 

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Find.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Find.java
@@ -97,9 +97,9 @@ public class Find implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         Path filePath = Paths.get(file);
-        int exitCode = Exists.call(filePath);
-        if (exitCode > 0) {
-            return exitCode;
+        if (Files.notExists(filePath)) {
+            System.out.println("File " + filePath + " does not exists");
+            return 0;
         }
         printFilePath(filePath, 0);
         return 0;

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Remove.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/src/main/java/com/aws/greengrass/testing/pillbox/commands/files/Remove.java
@@ -41,7 +41,8 @@ public class Remove implements Callable<Integer> {
                 files.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
             }
         } else {
-            System.out.println("cannot remove '" + filePath + "': Is a directory");
+            System.err.println("cannot remove '" + filePath + "': Is a directory");
+            return 1;
         }
         return 0;
     }


### PR DESCRIPTION
**Issue #, if available:**
Issue: P60056740

**Description of changes:**
Pillbox jar was returning exit code as 1 if the file does not exist which in turn throwing the CommandExecutionException, which is not the ideal scenario. The exception should be thrown if there is a problem with the command to be executed.

**Why is this change necessary:**
The command was executing successfully thus the exit code needs to be changed from 1 to 0.

**How was this change tested:**
Changes are tested on remote DUT (Windows and Linux) through IDT setup on Linux device.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
