### PR TITLE
fix: using public ecr for metadata images

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/component/recipes/DockerHubAmazonContainer.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/component/recipes/DockerHubAmazonContainer.yaml
@@ -9,4 +9,4 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "docker:amazon/amazon-ec2-metadata-mock:v1.9.0"
+      - URI: "docker:public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.10.1"

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/features/docker.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/features/docker.feature
@@ -6,9 +6,9 @@ Feature: Greengrass V2 Docker Component
 
   @Docker @IDT
   Scenario: I can deploy Docker containers as Greengrass Components
-    Given the docker image amazon/amazon-ec2-metadata-mock:v1.9.0 does not exist on the device
+    Given the docker image public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.10.1 does not exist on the device
     And I create a Greengrass deployment with components
       | DockerHubAmazonContainer | classpath:/greengrass/component/recipes/DockerHubAmazonContainer.yaml |
     When I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 2 minutes
-    And I can check that the docker image amazon/amazon-ec2-metadata-mock:v1.9.0 exists on the device
+    And I can check that the docker image public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.10.1 exists on the device


### PR DESCRIPTION
**Issue #, if available:**
we should using public ECR instead of Dockerhub. 
**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
run with standalone jar

java \
-Dggc.archive=greengrass-nucleus-latest.zip \
-Dtest.log.path=aws-greengrass-testing-standalone/test-results \
-jar /Users/guoje/workplace/OTF/aws-greengrass-testing/aws-greengrass-testing-standalone/target/aws-greengrass-testing-standalone.jar

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
