### PR TITLE
fix: fix certificate spec to run ml test locally

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.testing.model.RegistrationContext;
 import com.aws.greengrass.testing.model.ScenarioContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.resources.AWSResources;
+import com.aws.greengrass.testing.resources.iot.IotCertificateSpec;
 import com.aws.greengrass.testing.resources.iot.IotLifecycle;
 import com.aws.greengrass.testing.resources.iot.IotThingSpec;
 import io.cucumber.guice.ScenarioScoped;
@@ -87,6 +88,9 @@ public class MQTTSteps {
                     .createCertificate(true)
                     .thingName(testContext.testId().idFor("host-mqtt"))
                     .policySpec(iotSteps.createDefaultPolicy("host-mqtt-policy"))
+                    .certificateSpec(IotCertificateSpec.builder()
+                            .thingName(testContext.testId().idFor("host-mqtt"))
+                            .build())
                     .build());
             try (EventLoopGroup loopGroup = new EventLoopGroup(1);
                  HostResolver resolver = new HostResolver(loopGroup);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add certificate spec in MQTT steps to run ml tests locally with standalone jar

**Why is this change necessary:**
While creating connection with mqtt client to deploy ml components Certificate specs were missing this failing.

**How was this change tested:**
Tested on linux machine with standalone jar

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
