### PR TITLE
Updating local deployment test to deploy the same CLI version as nucleus

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.component;
 import com.aws.greengrass.testing.api.ComponentPreparationService;
 import com.aws.greengrass.testing.api.model.ComponentOverrideNameVersion;
 import com.aws.greengrass.testing.api.model.ComponentOverrideVersion;
+import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
@@ -23,13 +24,23 @@ import javax.inject.Inject;
 
 public class CloudComponentPreparationService implements ComponentPreparationService {
     private static final String LATEST = "LATEST";
+    private static final String NUCLEUS_VERSION = "NUCLEUS_VERSION";
     private final GreengrassV2Lifecycle ggv2;
     private final Region currentRegion;
+    private final GreengrassContext ggContext;
 
+    /**
+     * Constructor.
+     * @param ggv2 {@link GreengrassV2Lifecycle}
+     * @param currentRegion {@link Region}
+     * @param ggContext Greengrass context
+     */
     @Inject
-    public CloudComponentPreparationService(final GreengrassV2Lifecycle ggv2, final Region currentRegion) {
+    public CloudComponentPreparationService(final GreengrassV2Lifecycle ggv2, final Region currentRegion,
+                                            final GreengrassContext ggContext) {
         this.currentRegion = currentRegion;
         this.ggv2 = ggv2;
+        this.ggContext = ggContext;
     }
 
     private Optional<Component> pinpointComponent(ComponentOverrideNameVersion nameVersion) {
@@ -93,6 +104,8 @@ public class CloudComponentPreparationService implements ComponentPreparationSer
                 .map(component -> {
                     if (nameVersion.version().value().equals(LATEST)) {
                         return convert(nameVersion, component.latestVersion().componentVersion());
+                    } else if (nameVersion.version().value().equals(NUCLEUS_VERSION)) {
+                        return convert(nameVersion, ggContext.version());
                     } else {
                         return convert(nameVersion, pinpointViableVersion(nameVersion, component));
                     }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -7,7 +7,7 @@ Feature: Testing local deployment using CLI in Greengrass
   @LocalDeployment @IDT
   Scenario: A component is deployed locally using CLI
     When I create a Greengrass deployment with components
-      | aws.greengrass.Cli | LATEST |
+      | aws.greengrass.Cli | NUCLEUS_VERSION |
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     Then I verify greengrass-cli is available in greengrass root

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/java/com/aws/greengrass/testing/features/mqtt/MQTTSteps.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.testing.model.RegistrationContext;
 import com.aws.greengrass.testing.model.ScenarioContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.resources.AWSResources;
+import com.aws.greengrass.testing.resources.iot.IotCertificateSpec;
 import com.aws.greengrass.testing.resources.iot.IotLifecycle;
 import com.aws.greengrass.testing.resources.iot.IotThingSpec;
 import io.cucumber.guice.ScenarioScoped;
@@ -87,6 +88,9 @@ public class MQTTSteps {
                     .createCertificate(true)
                     .thingName(testContext.testId().idFor("host-mqtt"))
                     .policySpec(iotSteps.createDefaultPolicy("host-mqtt-policy"))
+                    .certificateSpec(IotCertificateSpec.builder()
+                            .thingName(testContext.testId().idFor("host-mqtt"))
+                            .build())
                     .build());
             try (EventLoopGroup loopGroup = new EventLoopGroup(1);
                  HostResolver resolver = new HostResolver(loopGroup);


### PR DESCRIPTION
**Issue #, if available:**
Today local deployment test pulls the latest version of CLI and deploys that. If customer is using older nucleus, latest version of cli may not be compatible with it. That results in test failure

**Description of changes:**
These changes update the test to pull the CLI with same version as that of nucleus.

**Why is this change necessary:**
To pull compatible version of CLI

**How was this change tested:**
Ran the test locally on my laptop successfully. For nucles 2.5.3, it pulls CLI 2.5.3

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
