### PR TITLE
chore: create jar without awssdk

### DIFF
--- a/aws-greengrass-testing-standalone/pom.xml
+++ b/aws-greengrass-testing-standalone/pom.xml
@@ -19,6 +19,7 @@
                 <version>3.2.4</version>
                 <executions>
                     <execution>
+                        <id>otfStandalone</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
@@ -33,6 +34,29 @@
                             </artifactSet>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>otfStandaloneWithoutAwsSdk</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>aws-greengrass-testing-without-awssdk</finalName>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>io.netty:*</exclude>
+                                    <exclude>com.typesafe.netty:*</exclude>
+                                    <exclude>software.amazon.awssdk:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
@@ -87,5 +111,4 @@
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
**Issue #, if available:**
Amazon internal consumers of jar want to use their own versions of AWS SDK. For such consumers an artifact jar without AWS SDK is needed. 

**Description of changes:**
Creating jar without AWS SDK. 

**Why is this change necessary:**
For unblocking Amazon 2p customers

**How was this change tested:**
Ran a local test of one of the internal customer's component using the newly created jar. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
