### PR TITLE
Test with ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,16 @@
-name: CI with Maven
+name: Build then UAT
 on:
+  workflow_dispatch:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+      - 'external_pr_*'
   pull_request:
     branches: '*'
+env:
+  AWS_REGION : "us-west-2"
+  CODE_BUILD_PROJECT_LINUX: "OtfUatCodeBuildLinux"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -24,3 +31,26 @@ jobs:
         run: mvn -U -ntp process-resources
       - name: Build with Maven
         run: mvn -U -ntp clean verify
+
+  uat-linux:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::686385081908:role/aws-greengrass-testing-codebuild-uat-role-amazonlinux
+          role-session-name: otfCI
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Run UAT on linux
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ env.CODE_BUILD_PROJECT_LINUX }}
+          buildspec-override: codebuild/uat_linux_buildspec.yaml
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## AWS Greengrass Testing Framework
 
-Test update
-
 This framework is a collection of building blocks
 to support end to end automation from the customer
 perspective, using Cucumber as the feature driver. AWS Greengrass uses these very same building

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -4,7 +4,7 @@ Feature: Testing Cloud component in Greengrass
     Given my device is registered as a Thing
     And my device is running Greengrass
 
-  @CloudDeployment @IDT
+  @CloudDeployment @IDT @OTFStable
   Scenario: As a developer, I can create a component in Cloud and deploy it on my device
     When I create a Greengrass deployment with components
       | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |
@@ -18,7 +18,7 @@ Feature: Testing Cloud component in Greengrass
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds
 
-  @CloudDeployment @IDT
+  @CloudDeployment @IDT @OTFStable
   Scenario: As a developer, I can create a component in Cloud and deploy it on my device via thing group
     When I create a Greengrass deployment with components
       | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -4,7 +4,7 @@ Feature: Testing local deployment using CLI in Greengrass
     Given my device is registered as a Thing
     And my device is running Greengrass
 
-  @LocalDeployment @IDT
+  @LocalDeployment @IDT @OTFStable
   Scenario: A component is deployed locally using CLI
     When I create a Greengrass deployment with components
       | aws.greengrass.Cli | NUCLEUS_VERSION |

--- a/aws-greengrass-testing-standalone/pom.xml
+++ b/aws-greengrass-testing-standalone/pom.xml
@@ -19,29 +19,6 @@
                 <version>3.2.4</version>
                 <executions>
                     <execution>
-                        <id>otfStandalone</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>aws-greengrass-testing-standalone</finalName>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>io.netty:*</exclude>
-                                    <exclude>com.typesafe.netty:*</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>otfStandaloneWithoutAwsSdk</id>
                         <phase>package</phase>
                         <goals>
@@ -54,14 +31,61 @@
                                     <exclude>io.netty:*</exclude>
                                     <exclude>com.typesafe.netty:*</exclude>
                                     <exclude>software.amazon.awssdk:*</exclude>
+                                    <exclude>org.apache.logging.log4j.core.lookup.JndiLookup</exclude>
                                 </excludes>
                             </artifactSet>
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
                                 </transformer>
                             </transformers>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>otfStandalone</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>io.netty:*</exclude>
+                                    <exclude>com.typesafe.netty:*</exclude>
+                                    <exclude>org.apache.logging.log4j.core.lookup.JndiLookup</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>Creating Symlink to artifact</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>ln</executable>
+                            <arguments>
+                                <argument>-fnsv</argument>
+                                <argument>${artifactId}-${project.version}.jar</argument>
+                                <argument>target/aws-greengrass-testing-standalone.jar</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/codebuild/uat_linux_buildspec.yaml
+++ b/codebuild/uat_linux_buildspec.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+version: 0.2
+env:
+  exported-variables:
+    - requestor
+    - event-name
+phases:
+  install:
+    runtime-versions:
+      java: corretto11
+  build:
+    commands:
+      - curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip --output aws.greengrass.nucleus.zip
+      - git submodule update --init
+      - mvn -U -ntp process-resources
+      - mvn clean -U -ntp verify -DskipTests=true
+      - ls -lrt ./aws-greengrass-testing-standalone/target/aws-greengrass-testing-standalone.jar
+      - java -Dggc.archive=./aws.greengrass.nucleus.zip
+        -Dtags=OTFStable -Dggc.install.root=$CODEBUILD_SRC_DIR -Dggc.log.level=INFO -Daws.region=us-east-1
+        -jar ./aws-greengrass-testing-standalone/target/aws-greengrass-testing-standalone.jar
+
+artifacts:
+  files:
+    - 'testResults/**/*'
+  name: 'OtfUatLinuxLogs.zip'
+
+reports:
+  uat-reports:
+    files:
+      - "TEST-greengrass-results.xml"
+    file-format: "JUNITXML"


### PR DESCRIPTION
**Issue #, if available:**
Adding UAT run in a codebuild project. This will be a reference for other teams to run their UATs as part of github workflow. 

**Description of changes:**
Using OIDC (open Id connect) for getting temporary AWS creds, that will be used for triggering the codebuild. Codebuild will run the OTF UATs. 

**Why is this change necessary:**

**How was this change tested:**
The PR has triggered a github workflow which ran UAT in codebuild. The run is successful

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
