### PR TITLE
feat: add support for group deployments

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -17,3 +17,17 @@ Feature: Testing Cloud component in Greengrass
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds
+
+  @CloudDeployment @IDT
+  Scenario: As a developer, I can create a component in Cloud and deploy it on my device via thing group
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |
+    And I deploy the Greengrass deployment configuration to thing group
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World!!" within 20 seconds
+    # Deployment with new version
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_updated_recipe.yaml |
+    And I deploy the Greengrass deployment configuration to thing group
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentSpecModel.java
@@ -73,6 +73,7 @@ interface GreengrassDeploymentSpecModel extends ResourceSpec<GreengrassV2Client,
                         lc.listThingsForGroup(group.groupName()).things().stream().forEach(thingNames::add);
                     });
         });
+
         CreateDeploymentResponse created = client.createDeployment(CreateDeploymentRequest.builder()
                 .targetArn(targetArn.get())
                 .deploymentName(deploymentName())

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotLifecycle.java
@@ -13,7 +13,9 @@ import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.DescribeEndpointRequest;
 import software.amazon.awssdk.services.iot.model.DescribeThingRequest;
 import software.amazon.awssdk.services.iot.model.DescribeThingResponse;
+import software.amazon.awssdk.services.iot.model.ListThingGroupsForThingRequest;
 import software.amazon.awssdk.services.iot.model.ListThingsInThingGroupRequest;
+import software.amazon.awssdk.services.iot.paginators.ListThingGroupsForThingIterable;
 import software.amazon.awssdk.services.iot.paginators.ListThingsInThingGroupIterable;
 
 import javax.inject.Inject;
@@ -80,6 +82,17 @@ public class IotLifecycle extends AbstractAWSResourceLifecycle<IotClient> {
         return client.listThingsInThingGroupPaginator(ListThingsInThingGroupRequest.builder()
                 .recursive(true)
                 .thingGroupName(thingGroupName)
+                .build());
+    }
+
+    /**
+     * List the thing groups for a thing.
+     * @param thingName name of the thing
+     * @return
+     */
+    public ListThingGroupsForThingIterable listThingGroupsForAThing(String thingName) {
+        return client.listThingGroupsForThingPaginator(ListThingGroupsForThingRequest.builder()
+                .thingName(thingName)
                 .build());
     }
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/src/main/java/com/aws/greengrass/testing/resources/iot/IotThingSpecModel.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.resources.ResourceSpec;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.iot.IotClient;
+import software.amazon.awssdk.services.iot.model.AddThingToThingGroupRequest;
 import software.amazon.awssdk.services.iot.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.iot.model.AttachThingPrincipalRequest;
 import software.amazon.awssdk.services.iot.model.CreateThingRequest;
@@ -63,6 +64,14 @@ interface IotThingSpecModel extends ResourceSpec<IotClient, IotThing>, IotTaggin
         CreateThingResponse createdThing = client.createThing(CreateThingRequest.builder()
                 .thingName(thingName())
                 .build());
+
+        createdGroups.stream().forEach(g -> {
+            client.addThingToThingGroup(AddThingToThingGroupRequest.builder()
+                    .thingArn(createdThing.thingArn())
+                    .thingGroupName(g.groupName())
+                    .build());
+        });
+
 
         String certificateArn = null;
         if (createCertificate()) {


### PR DESCRIPTION
**Issue #, if available:**
OTF does not support thing group deployments. 

**Description of changes:**
Adding support for thing group deployments in OTF

**Why is this change necessary:**
Need for L4V. Possibly needed for IDT pre-release. Will be needed for GG UATs

**How was this change tested:**
Ran the new UAT successfully on my dev machine.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
