### PR TITLE
fix:make the constructors public for scenario scoped classes to addre…

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/AWSResourcesSteps.java
@@ -23,7 +23,7 @@ public class AWSResourcesSteps implements Closeable {
     private final TestContext testContext;
 
     @Inject
-    AWSResourcesSteps(
+    public AWSResourcesSteps(
             final AWSResources resources,
             final TestContext testContext) {
         this.resources = resources;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -67,7 +67,8 @@ public class DeploymentSteps {
     private Path recipePath;
 
     @Inject
-    DeploymentSteps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public DeploymentSteps(
             final AWSResources resources,
             final ComponentOverrides overrides,
             final TestContext testContext,

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -60,7 +60,8 @@ public class FileSteps {
     }
 
     @Inject
-    FileSteps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public FileSteps(
             Platform platform,
             TestContext testContext,
             ScenarioContext scenarioContext,

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
@@ -42,7 +42,8 @@ public class GreengrassCliSteps {
     private static Logger LOGGER = LogManager.getLogger(GreengrassCliSteps.class);
 
     @Inject
-    GreengrassCliSteps(Platform platform, TestContext testContext,
+    @SuppressWarnings("MissingJavadocMethod")
+    public GreengrassCliSteps(Platform platform, TestContext testContext,
                        ComponentPreparationService componentPreparation,
                        ScenarioContext scenarioContext, WaitSteps waitSteps) {
         this.platform = platform;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassSteps.java
@@ -20,7 +20,7 @@ public class GreengrassSteps implements Closeable {
     private final FileSteps files;
 
     @Inject
-    GreengrassSteps(
+    public GreengrassSteps(
             final Greengrass greengrass,
             final FileSteps files) {
         this.greengrass = greengrass;

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IamSteps.java
@@ -28,7 +28,8 @@ public class IamSteps {
     private final AWSResourcesContext context;
 
     @Inject
-    IamSteps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public IamSteps(
             TestId testId,
             @Named(JacksonModule.YAML) ObjectMapper mapper,
             AWSResourcesContext context,

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/IotSteps.java
@@ -28,7 +28,8 @@ public class IotSteps {
     private final TestId testId;
 
     @Inject
-    IotSteps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public IotSteps(
             final TestId testId,
             final AWSResources resources,
             @Named(JacksonModule.YAML) final ObjectMapper mapper) {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
@@ -25,7 +25,7 @@ public class LoggerSteps {
     private final TestContext testContext;
 
     @Inject
-    LoggerSteps(final TestContext testContext) {
+    public LoggerSteps(final TestContext testContext) {
         this.testContext = testContext;
     }
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -60,7 +60,8 @@ public class RegistrationSteps {
     private final FileSteps fileSteps;
 
     @Inject
-    RegistrationSteps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public RegistrationSteps(
             Platform platform,
             AWSResources resources,
             IamSteps iamSteps,

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/S3Steps.java
@@ -25,7 +25,8 @@ public class S3Steps {
     private final WaitSteps waits;
 
     @Inject
-    S3Steps(
+    @SuppressWarnings("MissingJavadocMethod")
+    public S3Steps(
             final AWSResources resources,
             final TestId testId,
             final WaitSteps waits) {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/WaitSteps.java
@@ -20,7 +20,7 @@ public class WaitSteps {
     private final TimeoutMultiplier multiplier;
 
     @Inject
-    WaitSteps(TimeoutMultiplier multiplier) {
+    public WaitSteps(TimeoutMultiplier multiplier) {
         this.multiplier = multiplier;
     }
 


### PR DESCRIPTION
…ss guice injection error

**Issue #, if available:**
We are seeing guice injection issues due to constructor visibility. 

**Description of changes:**
Making the constructors of ScenarioScoped classes public to mitigate the issue.

**Why is this change necessary:**
Customer seeing Guice configuration errors while running IDT, and customer is blocked

**How was this change tested:**
Verified by running UAT on dev machine.
 
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
