### PR TITLE
chore: add debug logs during greengrass stop

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/DefaultGreengrass.java
@@ -133,6 +133,8 @@ public class DefaultGreengrass implements Greengrass {
                 platform.commands().killAll(greengrassProcess);
                 if (!waits.untilTrue(() -> platform.commands().findDescendants(greengrassProcess).size() == 1,
                         30, TimeUnit.SECONDS)) {
+                    LOGGER.error("The pids of descendants of greengrass process still active are "
+                            + platform.commands().findDescendants(greengrassProcess));
                     throw new IllegalStateException("Failed to successfully remove the Greengrass process "
                             + greengrassProcess);
                 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -104,11 +104,12 @@ public abstract class UnixCommands implements Commands, UnixPathsMixin {
 
     @Override
     public void kill(List<Integer> processIds) throws CommandExecutionException {
-        execute(CommandInput.builder()
-            .line("kill " + processIds.stream()
+        String output = executeToString(CommandInput.builder()
+            .line("kill -9 " + processIds.stream()
                     .map(i -> Integer.toString(i))
                     .collect(Collectors.joining(" ")))
             .build());
+        LOGGER.debug("Output of kill command : " + output);
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**
Otf UAT are failing in the nucleus otf branch. 

**Description of changes:**
Adding debug logs to investigate further.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
