### PR TITLE
feat: add parameter to generate cucumber json report

### DIFF
--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
@@ -113,6 +113,11 @@ public final class TestLauncher {
             optionsBuilder.addPluginName("junit:" + resultsXml, true);
         }
 
+        if (values.getBoolean(TestLauncherParameters.TEST_RESULTS_JSON).orElse(true)) {
+            final Path resultsJson = output.toAbsolutePath().resolve("cucumber.json");
+            optionsBuilder.addPluginName("json:" + resultsJson, true);
+        }
+
         // Allow external feature files. This enables framework features to work with static features.
         values.getString(TestLauncherParameters.FEATURE_PATH).ifPresent(featurePath -> {
             try (DirectoryStream<Path> paths = Files.newDirectoryStream(Paths.get(featurePath), "*.feature")) {

--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncherParameters.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncherParameters.java
@@ -19,6 +19,7 @@ public class TestLauncherParameters implements Parameters {
     static final String FEATURE_PATH = "feature.path";
     static final String TEST_RESULTS_LOG = "test.results.log";
     static final String TEST_RESULTS_XML = "test.results.xml";
+    static final String TEST_RESULTS_JSON = "test.results.json";
     static final String ADDITIONAL_PLUGINS = "additional.plugins";
 
     @Override
@@ -36,6 +37,11 @@ public class TestLauncherParameters implements Parameters {
                         .name(TEST_RESULTS_XML)
                         .description("Flag to determine if a resulting JUnit XML report is generated written to disk. "
                                 + "Defaults to true.")
+                        .build(),
+                Parameter.builder()
+                        .name(TEST_RESULTS_JSON)
+                        .description("Flag to determine if a resulting cucumber json report is generated written to "
+                                + "disk. Defaults to true.")
                         .build(),
                 Parameter.of(LOG_LEVEL, "Log level of the test run. Defaults to \"INFO\""),
                 Parameter.of(ADDITIONAL_PLUGINS, "Optional additional Cucumber plugins.")


### PR DESCRIPTION
**Issue #, if available:**
Adding configuration to launcher to generate json report. 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
Needed for Greenlight to parse cucumber.json for OTF tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
