### PR TITLE
fix: parse exclaimation as not in tags

### DIFF
--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/TestLauncher.java
@@ -96,6 +96,7 @@ public final class TestLauncher {
                 // Assuming JUnit style tags being supplied here
                 final Matcher matcher = Pattern.compile("([A-Za-z0-9_\\.]+)").matcher(tags);
                 tags = matcher.replaceAll("@$1")
+                        .replace("!", "not ")
                         .replace("&", " and ")
                         .replace("|", " or ");
             }


### PR DESCRIPTION
**Issue #, if available:**
'!' is not parsed as a not in tags

**Description of changes:**
Replace '!' with 'not ' in the tags

**Why is this change necessary:**

**How was this change tested:**
Ran UAT and locally, printed the tags used and  verified. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
