### PR TITLE
Check pillbox.jar exists before deleting

### DIFF
--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/remote/AbstractRemoteDevice.java
@@ -54,11 +54,13 @@ public abstract class AbstractRemoteDevice implements Device {
                     .addArgs("del " +  pillboxContext.onDevice().toString())
                     .build());
         } else {
-            execute(CommandInput.builder()
-                    .line("java")
-                    .addArgs("-jar", pillboxContext.onDevice().toString(),
-                            "files", "rm", pillboxContext.onDevice().toString())
-                    .build());
+            if (exists(pillboxContext.onDevice().toString())) {
+                execute(CommandInput.builder()
+                        .line("java")
+                        .addArgs("-jar", pillboxContext.onDevice().toString(),
+                                "files", "rm", pillboxContext.onDevice().toString())
+                        .build());
+            }
         }
     }
 }


### PR DESCRIPTION
**Description of changes:**
Check pillbox jar exists before deleting on linux devices.

**Why is this change necessary:**
IDT integration tests fail due to a 'Error: Unable to access jarfile pillbox.jar' issue.

**How was this change tested:**
Tested against a local raspberry pi as this is specific to linux devices. In windows the pillbox jar file is deleted using command line.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
