### PR TITLE
feat: hsm config verification for preinstalled

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -5,12 +5,15 @@
 
 package com.aws.greengrass.testing.features;
 
+import com.aws.greengrass.testing.DefaultGreengrass;
 import com.aws.greengrass.testing.api.ParameterValues;
 import com.aws.greengrass.testing.api.model.ProxyConfig;
 import com.aws.greengrass.testing.model.RegistrationContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.FeatureParameters;
 import com.aws.greengrass.testing.modules.HsmParameters;
+import com.aws.greengrass.testing.modules.JacksonModule;
+import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
 import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.platform.Platform;
 import com.aws.greengrass.testing.resources.AWSResources;
@@ -24,6 +27,8 @@ import com.aws.greengrass.testing.resources.iot.IotRoleAliasSpec;
 import com.aws.greengrass.testing.resources.iot.IotThing;
 import com.aws.greengrass.testing.resources.iot.IotThingGroupSpec;
 import com.aws.greengrass.testing.resources.iot.IotThingSpec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Given;
 import org.apache.logging.log4j.LogManager;
@@ -41,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import static com.aws.greengrass.testing.modules.HsmParameters.ROOT_CA_PATH;
 
@@ -58,6 +64,7 @@ public class RegistrationSteps {
     private final IamLifecycle iamLifecycle;
     private final ParameterValues parameterValues;
     private final FileSteps fileSteps;
+    private final ObjectMapper mapper;
 
     @Inject
     @SuppressWarnings("MissingJavadocMethod")
@@ -71,7 +78,8 @@ public class RegistrationSteps {
             AWSResourcesContext resourcesContext,
             IamLifecycle iamLifecycle,
             ParameterValues parameterValues,
-            FileSteps fileSteps) {
+            FileSteps fileSteps,
+            @Named(JacksonModule.YAML) ObjectMapper objectMapper) {
         this.platform = platform;
         this.resources = resources;
         this.iamSteps = iamSteps;
@@ -82,6 +90,7 @@ public class RegistrationSteps {
         this.iamLifecycle = iamLifecycle;
         this.parameterValues = parameterValues;
         this.fileSteps = fileSteps;
+        this.mapper = objectMapper;
     }
 
     /**
@@ -99,13 +108,19 @@ public class RegistrationSteps {
     }
 
     @Given("my device is registered as a Thing")
+    @SuppressWarnings("MissingJavadocMethod")
     public void registerAsThing() throws IOException {
-        registerAsThing(null);
+        if (!testContext.initializationContext().persistInstalledSoftware()) {
+            registerAsThing(null);
+        }
+        if (testContext.initializationContext().persistInstalledSoftware()
+                && testContext.hsmConfigured()) {
+            checkHSMConfigForPreInstalled();
+        }
     }
 
     private void registerAsThing(String configName, String thingGroupName) throws IOException {
         final String configFile = Optional.ofNullable(configName).orElse(getDefaultConfigName());
-
         String tesRoleNameName = testContext.tesRoleName();
         Optional<IamRole> optionalIamRole = Optional.empty();
         if (!tesRoleNameName.isEmpty()) {
@@ -161,6 +176,20 @@ public class RegistrationSteps {
             return DEFAULT_HSM_CONFIG;
         }
         return DEFAULT_CONFIG;
+    }
+
+    private void checkHSMConfigForPreInstalled() {
+        Path configPath = testContext.installRoot().resolve("config")
+                .resolve("effectiveConfig.yaml");
+        byte[] bytes = platform.files().readBytes(configPath);
+        try {
+            JsonNode config = mapper.readTree(bytes);
+            if (!config.get("services").hasNonNull("aws.greengrass.crypto.Pkcs11Provider")) {
+                throw new IOException("Pkcs11 is not properly configured on device");
+            }
+        } catch (IOException e) {
+            throw new ModuleProvisionException(e);
+        }
     }
 
     private void setupConfig(
@@ -225,5 +254,4 @@ public class RegistrationSteps {
         platform.files().makeDirectories(testContext.installRoot().getParent());
         platform.files().copyTo(testContext.testDirectory(), testContext.installRoot());
     }
-
 }


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Check for PKCS11 config in effectiveConfig.yaml in case HSM is configured for PReInstalled use-case.

**Why is this change necessary:**
HSM config must be verified if customer does provisioning/installation by themselves

**How was this change tested:**
Tested with Raspberry Pi with linux. With and without HSM config.

**Any additional information or context required to review the change:**
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
