### PR TITLE
chore: check if s3 object exist before uploading

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/RecipeComponentPreparationService.java
@@ -103,9 +103,17 @@ public class RecipeComponentPreparationService implements ComponentPreparationSe
         if (parts[1].indexOf('/') == 0) {
             s3Key = parts[1].substring(1);
         }
+
+        String s3Path = "s3://" + (bucketName + "/" + s3Key);
+        S3Lifecycle s3 = resources.lifecycle(S3Lifecycle.class);
+        if (s3.objectExists(bucketName, s3Key)) {
+            LOGGER.debug("{} already exist in {}", s3Key, bucketName);
+            return s3Path;
+        }
+
         resources.create(S3ObjectSpec.of(s3Key, bucketName, componentArtifact));
-        LOGGER.info("Uploading {} to s3://{}/{}", componentArtifact, bucketName, s3Key);
-        return "s3://" + (bucketName + "/" + s3Key);
+        LOGGER.info("Uploaded {} to {}", componentArtifact, s3Path);
+        return s3Path;
     }
 
     private String getOrCreateBucket() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Same artifacts are getting uploaded to S3bucket irrespective of their existence. To avoid this a condition is used before upload to check if it exists in the S3 Bucket.

**Why is this change necessary:**
To avoid unnecessary uploads to S3 Bucket.

**How was this change tested:**
Tested on Linux DUT.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
