### PR TITLE
chore: bump aws sdk and iot sdk versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,13 @@
         <cucumber.version>5.7.0</cucumber.version>
         <immutables.version>2.8.2</immutables.version>
         <log4j.version>2.17.1</log4j.version>
-        <aws.sdk.version>2.17.192</aws.sdk.version>
+        <aws.sdk.version>2.17.254</aws.sdk.version>
         <auto.service.version>1.0</auto.service.version>
         <findbugs.version>3.0.2</findbugs.version>
         <guice.version>5.0.1</guice.version>
         <jackson.version>2.12.3</jackson.version>
         <semver.version>3.1.0</semver.version>
-        <iotdevicesdk.version>1.3.3</iotdevicesdk.version>
+        <iotdevicesdk.version>1.10.3</iotdevicesdk.version>
         <picocli.version>4.6.1</picocli.version>
         <dagger.version>2.37</dagger.version>
     </properties>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bumping aws sdk and iot sdk to their respective latest version to use aws-crt version > 0.16 to enable support for M1 chip macbooks.

**Why is this change necessary:**
Current version of aws-crt 0.12 does not support M1 chip Macs. Thus updating the versions of as sdk and iot device sdk to let aws-crt version to be updated.

**How was this change tested:**
Tested on M1chip laptop by local testing and by using non-M1 chip macs as host and DUT as Linux EC2 instance.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
