### PR TITLE
chore: update step completion log from debug to info

### DIFF
--- a/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/reporting/StepTrackingReporting.java
+++ b/aws-greengrass-testing-launcher/src/main/java/com/aws/greengrass/testing/launcher/reporting/StepTrackingReporting.java
@@ -55,7 +55,7 @@ public class StepTrackingReporting implements EventListener {
             String path = stepStarted.getTestCase().getUri().toString().replace("classpath:", "");
             Logger logger = scenarioToLogger.computeIfAbsent(stepStarted.getTestCase().getId(),
                     key -> LogManager.getLogger(path));
-            logger.info("line {}: '{}'", step.getStep().getLine(), step.getStep().getText());
+            logger.debug("Executing line {}: '{}'", step.getStep().getLine(), step.getStep().getText());
         }
     }
 
@@ -72,7 +72,7 @@ public class StepTrackingReporting implements EventListener {
                         stepFinished.getResult().getError());
                 builder.failed(true).message("Failed at '" + step.getStep().getText() + "'");
             } else {
-                logger.debug("Finished step: '{}' with status {}",
+                logger.info("Finished step: '{}' with status {}",
                         step.getStep().getText(),
                         stepFinished.getResult().getStatus());
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
As per the request of customer updating logs to print step status when finished.

**Why is this change necessary:**
Better customer experience.

**How was this change tested:**
Ran mqtt test locally.

```
[INFO]      [java] 16:58:51.404 [main] INFO  greengrass/features/mqtt.feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO]      [java] 16:58:52.397 [main] INFO  com.aws.greengrass.testing.DefaultGreengrass - Starting Greengrass on pid 42979
[INFO]      [java] 16:58:52.397 [main] INFO  greengrass/features/mqtt.feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO]      [java] 16:58:54.529 [main] INFO  com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO]      [java] 16:59:17.427 [main] INFO  com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO]      [java] 16:59:17.427 [main] INFO  com.aws.greengrass.testing.component.RecipeComponentPreparationService - Uploaded /var/folders/c7/4c2dj9r10gsd1xv4hhlrk77r0000gs/T/gg-testing-2206531731552015781/80c08f9905bc25493e8e/components/aws.greengrass.IotMqttPublisher/aws-greengrass-testing-features-mqtt.zip to s3://gg-80c08f9905bc25493e8e-gg-component-store/greengrass/components/artifacts/aws-greengrass-testing-features-mqtt.zip
[INFO]      [java] 16:59:18.626 [main] INFO  com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO]      [java] 16:59:18.626 [main] INFO  com.aws.greengrass.testing.component.RecipeComponentPreparationService - Created component aws.greengrass.IotMqttSubscriber:1.0.0-80c08f9905bc25493e8e from /greengrass/components/recipes/iot_mqtt_subscriber.yaml
[INFO]      [java] 16:59:20.365 [main] INFO  com.aws.greengrass.testing.resources.AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO]      [java] 16:59:20.365 [main] INFO  com.aws.greengrass.testing.component.RecipeComponentPreparationService - Created component aws.greengrass.IotMqttPublisher:1.0.0-80c08f9905bc25493e8e from /greengrass/components/recipes/iot_mqtt_publisher.yaml
[INFO]      [java] 16:59:20.366 [main] INFO  greengrass/features/mqtt.feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
