### PR TITLE
feat: apply jacoco steps for Unit test / Integration test coverage check

### DIFF
--- a/.github/scripts/cover2cover.py
+++ b/.github/scripts/cover2cover.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import sys
+import xml.etree.ElementTree as ET
+import re
+import os.path
+
+# branch-rate="0.0" complexity="0.0" line-rate="1.0"
+# branch="true" hits="1" number="86"
+
+def find_lines(j_package, filename):
+    """Return all <line> elements for a given source file in a package."""
+    lines = list()
+    sourcefiles = j_package.findall("sourcefile")
+    for sourcefile in sourcefiles:
+        if sourcefile.attrib.get("name") == os.path.basename(filename):
+            lines = lines + sourcefile.findall("line")
+    return lines
+
+def line_is_after(jm, start_line):
+    return int(jm.attrib.get('line', 0)) > start_line
+
+def method_lines(jmethod, jmethods, jlines):
+    """Filter the lines from the given set of jlines that apply to the given jmethod."""
+    start_line = int(jmethod.attrib.get('line', 0))
+    larger     = list(int(jm.attrib.get('line', 0)) for jm in jmethods if line_is_after(jm, start_line))
+    end_line   = min(larger) if len(larger) else 99999999
+
+    for jline in jlines:
+        if start_line <= int(jline.attrib['nr']) < end_line:
+            yield jline
+
+def convert_lines(j_lines, into):
+    """Convert the JaCoCo <line> elements into Cobertura <line> elements, add them under the given element."""
+    c_lines = ET.SubElement(into, 'lines')
+    for jline in j_lines:
+        mb = int(jline.attrib['mb'])
+        cb = int(jline.attrib['cb'])
+        ci = int(jline.attrib['ci'])
+
+        cline = ET.SubElement(c_lines, 'line')
+        cline.set('number', jline.attrib['nr'])
+        cline.set('hits', '1' if ci > 0 else '0') # Probably not true but no way to know from JaCoCo XML file
+
+        if mb + cb > 0:
+            percentage = str(int(100 * (float(cb) / (float(cb) + float(mb))))) + '%'
+            cline.set('branch',             'true')
+            cline.set('condition-coverage', percentage + ' (' + str(cb) + '/' + str(cb + mb) + ')')
+
+            cond = ET.SubElement(ET.SubElement(cline, 'conditions'), 'condition')
+            cond.set('number',   '0')
+            cond.set('type',     'jump')
+            cond.set('coverage', percentage)
+        else:
+            cline.set('branch', 'false')
+
+def guess_filename(path_to_class):
+    m = re.match('([^$]*)', path_to_class)
+    return (m.group(1) if m else path_to_class) + '.java'
+
+def add_counters(source, target):
+    target.set('line-rate',   counter(source, 'LINE'))
+    target.set('branch-rate', counter(source, 'BRANCH'))
+    target.set('complexity', counter(source, 'COMPLEXITY', sum))
+
+def fraction(covered, missed):
+    return covered / (covered + missed)
+
+def sum(covered, missed):
+    return covered + missed
+
+def counter(source, type, operation=fraction):
+    cs = source.findall('counter')
+    c = next((ct for ct in cs if ct.attrib.get('type') == type), None)
+
+    if c is not None:
+        covered = float(c.attrib['covered'])
+        missed  = float(c.attrib['missed'])
+
+        return str(operation(covered, missed))
+    else:
+        return '0.0'
+
+def convert_method(j_method, j_lines):
+    c_method = ET.Element('method')
+    c_method.set('name',      j_method.attrib['name'])
+    c_method.set('signature', j_method.attrib['desc'])
+
+    add_counters(j_method, c_method)
+    convert_lines(j_lines, c_method)
+
+    return c_method
+
+def convert_class(j_class, j_package):
+    c_class = ET.Element('class')
+    c_class.set('name',     j_class.attrib['name'].replace('/', '.'))
+    c_class.set('filename', guess_filename(j_class.attrib['name']))
+
+    all_j_lines = list(find_lines(j_package, c_class.attrib['filename']))
+
+    c_methods   = ET.SubElement(c_class, 'methods')
+    all_j_methods = list(j_class.findall('method'))
+    for j_method in all_j_methods:
+        j_method_lines = method_lines(j_method, all_j_methods, all_j_lines)
+        c_methods.append(convert_method(j_method, j_method_lines))
+
+    add_counters(j_class, c_class)
+    convert_lines(all_j_lines, c_class)
+
+    return c_class
+
+def convert_package(j_package):
+    c_package = ET.Element('package')
+    c_package.attrib['name'] = j_package.attrib['name'].replace('/', '.')
+
+    c_classes = ET.SubElement(c_package, 'classes')
+    for j_class in j_package.findall('class'):
+        # Only output the class if it has methods to be covered
+        if j_class.findall('method'):
+            c_classes.append(convert_class(j_class, j_package))
+
+    add_counters(j_package, c_package)
+
+    return c_package
+
+def convert_root(source, target, source_roots):
+    target.set('timestamp', str(int(source.find('sessioninfo').attrib['start']) / 1000))
+
+    sources     = ET.SubElement(target, 'sources')
+    for s in source_roots:
+        ET.SubElement(sources, 'source').text = s
+
+    packages = ET.SubElement(target, 'packages')
+    for package in source.findall('package'):
+        packages.append(convert_package(package))
+
+    add_counters(source, target)
+
+def jacoco2cobertura(filename, source_roots):
+    if filename == '-':
+        root = ET.fromstring(sys.stdin.read())
+    else:
+        tree = ET.parse(filename)
+        root = tree.getroot()
+
+    into = ET.Element('coverage')
+    convert_root(root, into, source_roots)
+    print('<?xml version="1.0" ?>')
+    print(ET.tostring(into, encoding='unicode'))
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: cover2cover.py FILENAME [SOURCE_ROOTS]")
+        sys.exit(1)
+
+    filename    = sys.argv[1]
+    source_roots = sys.argv[2:] if 2 < len(sys.argv) else '.'
+
+    jacoco2cobertura(filename, source_roots)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,47 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Init Submodule
+        run: git submodule update --init
       - name: Maven Preprocess
-        run: mvn -U -ntp process-resources
+        run: mvn -U -ntp clean process-resources
       - name: Build with Maven
         run: mvn -U -ntp clean verify
+      - name: Upload Failed Test Report
+        uses: actions/upload-artifact@v1.0.0
+        if: failure()
+        with:
+          name: Failed Test Report
+          path: aws-greengrass-testing-features/aws-greengrass-testing-features-api/target/surefire-reports
+      - name: Convert Jacoco unit test report to Cobertura
+        run: python3 .github/scripts/cover2cover.py aws-greengrass-testing-features/aws-greengrass-testing-features-api/target/jacoco-report/jacoco.xml src/main/java > aws-greengrass-testing-features/aws-greengrass-testing-features-api/target/jacoco-report/cobertura.xml
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v1.0.0
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: Coverage Report
+          path: aws-greengrass-testing-features/aws-greengrass-testing-features-api/target/jacoco-report
+      - name: cobertura-report-unit-test
+        uses: shaguptashaikh/cobertura-action@master
+        continue-on-error: true
+        with:
+          # The GITHUB_TOKEN for this repo
+          repo_token: ${{ github.token }}
+          # Path to the cobertura file.
+          path: aws-greengrass-testing-features/aws-greengrass-testing-features-api/target/jacoco-report/cobertura.xml
+          # If files with 100% should be skipped from report.
+          skip_covered: false
+          # Minimum allowed coverage percentage as an integer.
+          minimum_coverage: 60
+          # Show line rate as specific column.
+          show_line: true
+          # Show branch rate as specific column.
+          show_branch: true
+          # Use class names instead of the filename
+          show_class_names: true
+          # Use a unique name for the report and comment
+          report_name: Unit Tests Coverage Report
+
 
   uat-linux:
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ aws.greengrass.nucleus.zip
 dependency-reduced-pom.xml
 testResults
 cucumber.json
+*DS_Store

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/pom.xml
@@ -44,6 +44,80 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Exception*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>merge-results</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>*.exec</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>aggregate.exec</exclude>
+                                    </excludes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>${project.build.directory}/aggregate.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-merge-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/aggregate.exec</dataFile>
+                            <outputDirectory>target/jacoco-report</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -115,6 +189,36 @@
             <artifactId>${pillbox}</artifactId>
             <version>${project.parent.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>2.13.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.FeatureParameters;
 import com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle;
+import com.google.common.annotations.VisibleForTesting;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import software.amazon.awssdk.arns.Arn;
@@ -54,7 +55,8 @@ public class CloudComponentPreparationService implements ComponentPreparationSer
         this.testContext = testContext;
     }
 
-    private Optional<Component> pinpointComponent(ComponentOverrideNameVersion nameVersion) {
+    @VisibleForTesting
+    Optional<Component> pinpointComponent(ComponentOverrideNameVersion nameVersion) {
         // We'll scan through private component override
         final Optional<Component> privateComponent = ggv2.listComponents(ComponentVisibilityScope.PRIVATE)
                 .components()
@@ -83,7 +85,8 @@ public class CloudComponentPreparationService implements ComponentPreparationSer
                         .build());
     }
 
-    private ComponentOverrideNameVersion convert(ComponentOverrideNameVersion original, String componentVersion) {
+    @VisibleForTesting
+    ComponentOverrideNameVersion convert(ComponentOverrideNameVersion original, String componentVersion) {
         return ComponentOverrideNameVersion.builder()
                 .from(original)
                 .version(ComponentOverrideVersion.builder()

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/CloudComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/CloudComponentPreparationServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.component;
+
+import com.aws.greengrass.testing.api.model.ComponentOverrideNameVersion;
+import com.aws.greengrass.testing.api.model.ComponentOverrideVersion;
+import com.aws.greengrass.testing.model.GreengrassContext;
+import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.api.ParameterValues;
+import com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.greengrassv2.model.Component;
+import java.util.Optional;
+
+
+@ExtendWith(MockitoExtension.class)
+public class CloudComponentPreparationServiceTest {
+    Region currentRegion = Region.AF_SOUTH_1;
+
+    @Mock
+    GreengrassV2Lifecycle ggv2;
+
+    @Mock
+    GreengrassContext ggContext;
+
+    @Mock
+    ParameterValues parameterValues;
+
+    @Mock
+    TestContext testContext;
+
+    @InjectMocks
+    CloudComponentPreparationService componentPreparation;
+
+    @BeforeEach
+    public void setup() {
+        componentPreparation = Mockito.spy(new CloudComponentPreparationService(ggv2, currentRegion, ggContext, parameterValues, testContext));
+    }
+
+    @Test
+    void GIVEN_component_override_name_Version_WHEN_it_is_cloud_component_THEN_return_an_expected_componentOverrideNameVersion() {
+        // Kernel
+        Mockito.when(ggContext.version())
+                .thenReturn("mock_version");
+        Mockito.doReturn(Optional.ofNullable(Component.builder().componentName("NUCLEUS_VERSION").arn("mock_nucleus_arn").build()))
+                .when(componentPreparation).pinpointComponent(Mockito.any());
+
+        ComponentOverrideNameVersion overrideNameVersion = ComponentOverrideNameVersion.builder()
+                .name("mock_component_name")
+                .version(ComponentOverrideVersion.of("cloud", "NUCLEUS_VERSION"))
+                .build();
+
+        Optional<ComponentOverrideNameVersion> res = componentPreparation.prepare(overrideNameVersion);
+        Optional<ComponentOverrideNameVersion> convertedRes = Optional.ofNullable(componentPreparation.convert(overrideNameVersion, ggContext.version()));
+
+        assertEquals(res.get().name(), convertedRes.get().name());
+        assertEquals(res.get().version().value(), convertedRes.get().version().value());
+        assertEquals(res.get().version().type(), convertedRes.get().version().type());
+
+        // Cli
+        Mockito.doReturn(Optional.ofNullable("GG_CLI_VERSION")).when(parameterValues).getString(Mockito.any());
+        Mockito.doReturn(Optional.ofNullable(Component.builder().componentName("GG_CLI_VERSION").arn("mock_cli_arn").build()))
+                .when(componentPreparation).pinpointComponent(Mockito.any());
+
+        overrideNameVersion = ComponentOverrideNameVersion.builder()
+                .name("mock_component_name")
+                .version(ComponentOverrideVersion.of("cloud", "GG_CLI_VERSION"))
+                .build();
+
+        assertEquals(componentPreparation.prepare(overrideNameVersion).get().version().value(), "GG_CLI_VERSION");
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**

1. Add some jacoco steps static analysis steps for OTF, currently only emit some unit tests report. 
2. Also add some unit tests as example to kick the ball rolling...

**Why is this change necessary:**

**How was this change tested:**
1. Locally mvn verify succeed
2. GitHub actions succeeded in this PR
3. Report got generated and commented by bot.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
