### PR TITLE
fix: hanlde empty value for gg.cli.version param

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/CloudComponentPreparationService.java
@@ -121,8 +121,13 @@ public class CloudComponentPreparationService implements ComponentPreparationSer
                     } else if (nameVersion.version().value().equals(NUCLEUS_VERSION)) {
                         return convert(nameVersion, ggContext.version());
                     } else if (nameVersion.version().value().equals(GG_CLI_VERSION)) {
-                        return convert(nameVersion, parameterValues.getString(FeatureParameters.GG_CLI_VERSION).orElse(
-                                ggContext.version() == null ? testContext.coreVersion() : ggContext.version()));
+                        String componentVersion = parameterValues.getString(FeatureParameters.GG_CLI_VERSION)
+                                .orElse(ggContext.version() == null ? testContext.coreVersion() : ggContext.version());
+                        if (componentVersion.isEmpty()) {
+                            componentVersion =
+                                    ggContext.version() == null ? testContext.coreVersion() : ggContext.version();
+                        }
+                        return convert(nameVersion, componentVersion);
                     } else {
                         return convert(nameVersion, pinpointViableVersion(nameVersion, component));
                     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Empty values for "gg.cli.version" were throwing Validation Exception. handled it by setting it to default value which is Nucleus version.

**Why is this change necessary:**

**How was this change tested:**
Tested locally by running standalone jar.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
