### PR TITLE
fix: change otf version to snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </modules>
 
     <properties>
-        <revision>0.1.0</revision>
+        <revision>0.1.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change otf to snapshot version to bypass mvn deployment issue

**Why is this change necessary:**
Deployment failed;

**How was this change tested:**
mvn clean compile/package pass;

run test locally by: 
1. java -Dggc.archive=./aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/greengrass-nucleus-latest.zip -Dtags=OTFStable -Dggc.install.root=$CODEBUILD_SRC_DIR -Dggc.log.level=INFO -Daws.region=us-east-1 -jar ./aws-greengrass-testing-standalone/target/aws-greengrass-testing-standalone-0.1.0-SNAPSHOT.jar

2. mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test



**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
