### PR TITLE
fix: standalone version and global version to match what is uploaded to mvn repo

### DIFF
--- a/aws-greengrass-testing-api/pom.xml
+++ b/aws-greengrass-testing-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-cloudcomponent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-components</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-ggipc/pom.xml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-ggipc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-components</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/pom.xml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-components</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-components/pom.xml
+++ b/aws-greengrass-testing-components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-examples</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-examples/pom.xml
+++ b/aws-greengrass-testing-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-ml/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-ml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-streammanager/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-streammanager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-features</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-features/pom.xml
+++ b/aws-greengrass-testing-features/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-launcher/pom.xml
+++ b/aws-greengrass-testing-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-modules/pom.xml
+++ b/aws-greengrass-testing-modules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/pom.xml
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-platform</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/pom.xml
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-pillbox/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-platform</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-platform/pom.xml
+++ b/aws-greengrass-testing-platform/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/pom.xml
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-resources</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/pom.xml
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-resources</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/pom.xml
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iam/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-resources</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/pom.xml
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-iot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-resources</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/pom.xml
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing-resources</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-resources/pom.xml
+++ b/aws-greengrass-testing-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aws-greengrass-testing-standalone/pom.xml
+++ b/aws-greengrass-testing-standalone/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aws-greengrass-testing</artifactId>
         <groupId>com.aws.greengrass</groupId>
-        <version>${revision}</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.aws.greengrass</groupId>
     <artifactId>aws-greengrass-testing</artifactId>
     <packaging>pom</packaging>
-    <version>${revision}</version>
+    <version>1.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -29,7 +29,6 @@
     </modules>
 
     <properties>
-        <revision>0.1.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
**Description of changes:**
Bump project version  from `0.1.0-SNAPSHOT` to `1.0-SNAPSHOT` and hardcode `aws-greengrass-testing-standalone` version to `1.0-SNAPSHOT` instead of using `${revision}` property.

**Why is this change necessary:**

**Changing the project version to 1.0-SNAPSHOT **

The current version of OTF uploaded to cloudfront is version `1.0-SNAPSHOT` but when building OTF locally it builds version `0.1.0-SNAPSHOT` which makes the setup of OTF as a dependency confusing given when checking this repo you see version `0.1.0-SNAPSHOT` being built but when setting up OTF as a dependency of another project we have to use `1.0-SNAPSHOT` which always gets pulled from cloudfront. **Changing the global version to 1.0-SNAPSHOT** alleviates confusion regarding what version is being built and where it comes from

**Hardcoding aws-greengrass-testing-standalone to 1.0-SNAPSHOT and stop using ${revision} property**

Without this changes, other projects using OTF as a dependency will fail to fetch the dependency from the local maven repo is there is any. It will always try to go to the cloud to get the changes making it hard for developers to make changes to OTF and quickly test their changes locally.

As it was mentioned before the current version is set to `0.1.0-SNAPSHOT`. If you run `mvn clean install` the version 0.1-SNAPSHOT gets installed on the local maven repo and if another repo tries to use that local version, without this change it fails to find the local version and tries to fetch it from the cloud and fails with the following error

<img width="1700" alt="Screen Shot 2022-11-29 at 11 46 45 AM" src="https://user-images.githubusercontent.com/9203175/204623628-1ddf7cc5-e110-4b71-82cd-33b3d58f53fb.png">

**How was this change tested:**

Install the local version of this project `mvn clean install` ensure that log manager repo pulls the local version of OTF instead of the one on cloudfront, if  a version already exists on the maven local maven repo.
