### PR TITLE
chore: add flatten-maven-plugin in pom file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aws-greengrass-testing-features/**/*.jar
 greengrass-nucleus-latest.zip
 aws.greengrass.nucleus.zip
 dependency-reduced-pom.xml
+.flattened-pom.xml
 testResults
 cucumber.json
 *DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,31 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add flatten-maven-plugin in pom file so that the revision variable can be replaced with its value.

**Why is this change necessary:**

**How was this change tested:**
1. Tested it by running otfstable tag using the standalone jar
java -Dggc.archive=aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/greengrass-nucleus-latest.zip -Dtags=OTFStable ./aws-greengrass-testing-standalone/target/aws-greengrass-testing-standalone.jar

2. Tested by running mvn integration test: 
mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
