### PR TITLE
fix: fix IDT version

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
@@ -63,7 +64,8 @@ public class LoggerSteps {
     }
 
     private String getOTFVersionLogContent() {
-        final String otfVersion = LoggerSteps.class.getPackage().getImplementationVersion();
+        final String otfVersion = Optional.ofNullable(LoggerSteps.class.getPackage().getImplementationVersion())
+                .orElse("1.0.0-SNAPSHOT");
         return String.format("%s-%s", OTF_VERSION_PREFIX, otfVersion);
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
otf-null is presented during IDT run; 

**Description of changes:**
The version number for OTF is backed into the Standalone jar's Manifest. 
When customer is consuming the jar in their dependencies, they have to make changes in config to backed the version into their jar. 
This change is to set a default value to OTF version

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
