### PR TITLE
fix: integration test and uat local runs for Windows devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,14 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
       
 
 
-- Run the tests:
-```
-mvn clean -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test
-```
+- Run the integration tests (For Window device, open the Windows Command Prompt (cmd.exe) as an administrator to run below tests):
 
-- Run the MQTT tests:
-```
-mvn clean -DskipITs=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test
-```
-
-- Run the cloud component tests:
-```
-mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test
-```
+  - Example component tests: 
+    - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test```
+  - MQTT tests: `
+    - ```mvn clean -DskipITs=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test```
+  - Cloud component tests: 
+    - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test```
 
 __Running tests with an HSM__
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
 
 - Configure user on Windows device
     - Open the Windows Command Prompt (cmd.exe) as an administrator.
-    - Create user in the LocalSystem account on the Windows device. Replace **user_name** with the same name of your current system user. Replace **password** with a secure password.
+    - Create user in the LocalSystem account on the Windows device. Replace **user-name** with the same name of your current system user. Replace **password** with a secure password.
       - ```net user /add user-name password```
     - Download and install the [PsExec utility](https://learn.microsoft.com/en-us/sysinternals/downloads/psexec) from Microsoft on the device.
     - Use the PsExec utility to store the user name and password in the Credential Manager instance for the LocalSystem account.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
       
 
 
-- Run the integration tests (For Window device, open the Windows Command Prompt (cmd.exe) as an administrator to run below tests):
+- Run the integration tests (For Windows device, open the Windows Command Prompt (cmd.exe) as an administrator to run below tests):
 
   - Example component tests: 
     - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Replace `compile` with `package` to build shared jars.
 mvn clean compile
 ```
 
-__Run integration tests for the example component__
+__Run integration tests__
 
 - Download the latest Greengrass archive at the example component path:
 ```
@@ -91,6 +91,19 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
   test resources in the account. For instructions, see [Set default credentials and Region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup.html#setup-credentials). The credentials must be available on the device. Some options are:
   - Copy temporary credentials and set them as env variables
   - Set the AWS profile for your environment
+
+
+- Configure user on Windows device
+    - Open the Windows Command Prompt (cmd.exe) as an administrator.
+    - Create user in the LocalSystem account on the Windows device. Replace **user_name** with the same name of your current system user. Replace **password** with a secure password.
+      - ```net user /add user-name password```
+    - Download and install the [PsExec utility](https://learn.microsoft.com/en-us/sysinternals/downloads/psexec) from Microsoft on the device.
+    - Use the PsExec utility to store the user name and password in the Credential Manager instance for the LocalSystem account.
+      - Run the following command. Replace user-name and password with the user's user name and password that you set earlier.
+        - ```psexec -s cmd /c cmdkey /generic:user-name /user:user-name /pass:password```
+      - If the **PsExec License Agreement** opens, choose **Accept** to agree to the license and run the command.
+      
+
 
 - Run the tests:
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
 
   - Example component tests: 
     - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test```
-  - MQTT tests: `
+  - MQTT tests: 
     - ```mvn clean -DskipITs=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test```
   - Cloud component tests: 
     - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ curl https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zi
   - Set the AWS profile for your environment
 
 
-- Configure user on Windows device
+- Configure user credentials for Windows devices
     - Open the Windows Command Prompt (cmd.exe) as an administrator.
     - Create user in the LocalSystem account on the Windows device. Replace **user-name** with the same name of your current system user. Replace **password** with a secure password.
       - ```net user /add user-name password```

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -59,7 +59,13 @@ public class LocalDevice implements Device {
 
     @Override
     public byte[] execute(CommandInput input) throws CommandExecutionException {
-        final ProcessBuilder builder = new ProcessBuilder().command(input.line());
+        final ProcessBuilder builder;
+        if (("cmd.exe /c").equals(input.line())) {
+            builder = new ProcessBuilder().command("cmd.exe");
+            builder.command().add("/c");
+        } else {
+            builder = new ProcessBuilder().command(input.line());
+        }
         Optional.ofNullable(input.args()).ifPresent(args -> {
             args.forEach(builder.command()::add);
         });

--- a/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
+++ b/aws-greengrass-testing-api/src/main/java/com/aws/greengrass/testing/api/device/local/LocalDevice.java
@@ -36,6 +36,11 @@ public class LocalDevice implements Device {
     private static final Logger LOGGER = LogManager.getLogger(LocalDevice.class);
     public static final String TYPE = "LOCAL";
     private static final int BUFFER = 100_000;
+
+    private static final String WINDOWS_CMD = "cmd.exe";
+
+    private static final String WINDOWS_CMD_SLASH_C = "/c";
+
     private final TimeoutMultiplier multiplier;
     private final String id = UUID.randomUUID().toString();
 
@@ -59,12 +64,12 @@ public class LocalDevice implements Device {
 
     @Override
     public byte[] execute(CommandInput input) throws CommandExecutionException {
-        final ProcessBuilder builder;
-        if (("cmd.exe /c").equals(input.line())) {
-            builder = new ProcessBuilder().command("cmd.exe");
-            builder.command().add("/c");
-        } else {
-            builder = new ProcessBuilder().command(input.line());
+        // Temporary fix for running UATs on Windows locally
+        String windowsExecuteCommand = String.format("%s %s", WINDOWS_CMD, WINDOWS_CMD_SLASH_C);
+        final ProcessBuilder builder = new ProcessBuilder(input.line());
+        if ((windowsExecuteCommand).equals(input.line())) {
+            builder.command(WINDOWS_CMD);
+            builder.command().add(WINDOWS_CMD_SLASH_C);
         }
         Optional.ofNullable(input.args()).ifPresent(args -> {
             args.forEach(builder.command()::add);

--- a/aws-greengrass-testing-standalone/README.md
+++ b/aws-greengrass-testing-standalone/README.md
@@ -32,7 +32,7 @@ java \
 The results of the run can be found in `hello_world/test-results`.
 
 ## Run provided features
-You can also run features provided by this test framework.Here are the provided test features: 
+You can also run features provided by this test framework. Here are the provided test features: 
 - Basic test features:
   - [cloudComponent.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature): Validates device capability for cloud components. 
   - [localdeployment.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature): Validates device capability for local components.

--- a/aws-greengrass-testing-standalone/README.md
+++ b/aws-greengrass-testing-standalone/README.md
@@ -32,14 +32,18 @@ java \
 The results of the run can be found in `hello_world/test-results`.
 
 ## Run provided features
-You can also run features provided by this test framework.
-Here are the provided features: 
-- [cloudComponent.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature)
-- [docker.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/features/docker.feature)
-- [localdeployment.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature)
-- [ml.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-ml/src/main/resources/greengrass/features/ml.feature)
-- [mqtt.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/features/mqtt.feature)
-- [streammanager.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-streammanager/src/main/resources/greengrass/features/streammanager.feature)
+You can also run features provided by this test framework.Here are the provided test features: 
+- Basic test features:
+  - [cloudComponent.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature): Validates device capability for cloud components. 
+  - [localdeployment.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature): Validates device capability for local components.
+  - [mqtt.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/src/main/resources/greengrass/features/mqtt.feature): Validates that the device can subscribe and publish to AWS IoT Core MQTT topics.
+
+
+
+- Below test features are only supported for Linux-based Greengrass core devices.
+  - [streammanager.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-streammanager/src/main/resources/greengrass/features/streammanager.feature): Validates that the device can download, install, and run the AWS IoT Greengrass stream manager.
+  - [docker.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/resources/greengrass/features/docker.feature): Validates that the device can download a Docker container image from Amazon ECR.
+  - [ml.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-ml/src/main/resources/greengrass/features/ml.feature): Validates that the device can perform ML inference using the Deep Learning Runtime and TensorFlow Lite ML frameworks.
 
 Here is an example on running the end to end test for OTFStable tag:
 ```

--- a/aws-greengrass-testing-standalone/README.md
+++ b/aws-greengrass-testing-standalone/README.md
@@ -63,7 +63,9 @@ There are also additional parameters can be configured when executing the jar:
 
 **Note:** 
 - Windows has a path length limitation of 260 characters. Please keep your paths under the 260 character limit when using above parameters.
-- For running the aws-greengrass-testing-standlone.jar on Windows devices, you have to configure user credentials. (See *Configure user credentials for Windows devices* section in [README](../README.md))
+- For running the aws-greengrass-testing-standlone.jar on Windows devices: 
+  - You have to configure user credentials; (See *Configure user credentials for Windows devices* section in [README](../README.md))
+  - Open Windows Command Prompt (cmd.exe) as an administrator;
 
 
 [1]: https://docs.aws.amazon.com/greengrass/v2/developerguide/create-components.html#develop-component

--- a/aws-greengrass-testing-standalone/README.md
+++ b/aws-greengrass-testing-standalone/README.md
@@ -46,6 +46,8 @@ You can also run features provided by this test framework. Here are the provided
   - [ml.feature](../aws-greengrass-testing-features/aws-greengrass-testing-features-ml/src/main/resources/greengrass/features/ml.feature): Validates that the device can perform ML inference using the Deep Learning Runtime and TensorFlow Lite ML frameworks.
 
 Here is an example on running the end to end test for OTFStable tag:
+
+
 ```
 java \
 -Dggc.archive=greengrass-nucleus-latest.zip \
@@ -58,6 +60,11 @@ There are also additional parameters can be configured when executing the jar:
 - [FeatureParameters](../aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/FeatureParameters.java)
 - [HsmParameters](../aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/HsmParameters.java)
 - [ModuleParameters](../aws-greengrass-testing-modules/src/main/java/com/aws/greengrass/testing/modules/ModuleParameters.java)
+
+**Note:** 
+- Windows has a path length limitation of 260 characters. Please keep your paths under the 260 character limit when using above parameters.
+- For running the aws-greengrass-testing-standlone.jar on Windows devices, you have to configure user credentials. (See *Configure user credentials for Windows devices* section in [README](../README.md))
+
 
 [1]: https://docs.aws.amazon.com/greengrass/v2/developerguide/create-components.html#develop-component
 [2]: https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip


### PR DESCRIPTION
**Issue #, if available:**
Integration test and uat local runs for Windows devices are not working as expected.
~~~
com.aws.greengrass.testing.api.device.exception.CommandExecutionException: java.io.IOException: Cannot run program "cmd.exe /c": CreateProcess error=2, The system cannot find the file specified
~~~

**Description of changes:**
1. In [LocalDevice.java](https://github.com/aws-greengrass/aws-greengrass-testing/compare/fixWindowsLocalTests?expand=1&short_path=b335630#diff-410e8fa2128318300c8f49bc72581f20d4956a83f0346dd2a978b54ef764e288), append "cmd.exe" and "/c" separately to ProcessBuilder;
2. Update README with detailed instructions on how to run tests on Windows device

**Why is this change necessary:**

**How was this change tested:**
Run below tests in both Linux and Windows devices: 
- Integration tests: 
  - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-examples/aws-greengrass-testing-examples-component -am integration-test```
  - ```mvn clean -DskipITs=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/ -am integration-test```
  - ```mvn clean -DskipTests=false -pl aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/ -am integration-test```
- Standalone jar:
  -  ```java -Dggc.archive=greengrass-nucleus-latest.zip -Dtags=LocalDeployment -jar aws-greengrass-testing-standalone-1.0.0-SNAPSHOT.jar```
  - ```java -Dggc.archive=greengrass-nucleus-latest.zip -Dtags=CloudDeployment -jar aws-greengrass-testing-standalone-1.0.0-SNAPSHOT.jar```
  - ```java -Dggc.archive=greengrass-nucleus-latest.zip -Dtags=MqttIotCore -jar aws-greengrass-testing-standalone-1.0.0-SNAPSHOT.jar```



**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
