### PR TITLE
chore: skip uat-linux workflow for external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
 
 
   uat-linux:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
**Issue #, if available:**
UAT is failed for forked PRs and it should be skipped.
**Description of changes:**
Skip UAT run for external PRs
**Why is this change necessary:**

**How was this change tested:**
Tested by creating a PR from forked repository:
https://github.com/aws-greengrass/aws-greengrass-testing/pull/182
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
