### PR TITLE
feat: add steps for local deployment with configs

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -152,7 +152,7 @@ public class DeploymentSteps {
      * @throws InterruptedException InterruptedException could be throw out during the component deployment
      * @throws IOException          IOException could be throw out during preparation of the CLI command
      */
-    @When("I install the component {word} from local store with configuration otf")
+    @When("I install the component {word} from local store with configuration")
     public void installComponentWithConfiguration(final String componentName, final String configurationTable)
             throws InterruptedException, IOException {
         // read the recipe from local store, and get component name and version from recipe
@@ -188,9 +188,8 @@ public class DeploymentSteps {
                 "--recipeDir " + recipePath.toString()));
 
         for (Map.Entry<String, ComponentDeploymentSpecification> entry : components.entrySet()) {
-            commandArgs.add(" --merge ");
             String componentName = entry.getKey();
-            commandArgs.add(componentName + "=" + entry.getValue().componentVersion());
+            commandArgs.add(String.format(" --merge %s=%s", componentName, entry.getValue().componentVersion()));
             String updateConfigArgs = getCliUpdateConfigArgs(componentName, configuration);
             if (!updateConfigArgs.isEmpty()) {
                 commandArgs.add("--update-config '" + updateConfigArgs + "'");

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -200,7 +200,7 @@ public class DeploymentSteps {
             }
         }
         return CommandInput.builder()
-                .line(testContext.installRoot().resolve("bin").resolve("greengrass-cli").toString())
+                .line(formLineOfGgCli())
                 .addAllArgs(commandArgs)
                 .build();
     }
@@ -277,7 +277,7 @@ public class DeploymentSteps {
 
         try {
             String response = platform.commands().executeToString(CommandInput.builder()
-                    .line(testContext.installRoot().resolve("bin").resolve("greengrass-cli").toString())
+                    .line(formLineOfGgCli())
                     .addAllArgs(commandArgs)
                     .build());
             LOGGER.debug("The response from executing gg-cli command is {}", response);
@@ -295,6 +295,10 @@ public class DeploymentSteps {
                     retryCount);
             this.createLocalDeployment(componentNames, retryCount + 1);
         }
+    }
+
+    private String formLineOfGgCli() {
+        return testContext.installRoot().resolve("bin").resolve("greengrass-cli").toString();
     }
 
     @VisibleForTesting

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/features/DeploymentStepsTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/features/DeploymentStepsTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;
+import com.aws.greengrass.testing.api.device.Device;
 import com.aws.greengrass.testing.api.model.*;
 import com.aws.greengrass.testing.model.ScenarioContext;
 import com.aws.greengrass.testing.model.TestContext;
@@ -74,6 +75,9 @@ public class DeploymentStepsTest {
     Platform platform;
 
     @Mock
+    Device device;
+
+    @Mock
     IotThing iotThing;
 
     @Mock
@@ -96,7 +100,7 @@ public class DeploymentStepsTest {
 
     @InjectMocks
     DeploymentSteps deploymentSteps= Mockito.spy(new DeploymentSteps(resources, overrides, testContext,
-            componentPreparation, scenarioContext, waits, mapper, platform));
+            componentPreparation, scenarioContext, waits, mapper, platform, device));
 
     @Test
     void GIVEN_a_list_of_component_names_with_mixed_type_WHEN_create_deployment_with_this_list_and_then_update_the_configuration_of_one_component_THEN_a_deployment_is_made_first_and_the_deployment_get_updated_successfully() throws JsonProcessingException {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
Add this step since LogManager and ShadowManager need to install custom components for UATs. Therefore, this step is is for the local deployment of custom components with configuration and recipes. 
**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
