### PR TITLE
fix: remove formatting to see if breaks tests

### DIFF
--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -58,6 +58,8 @@ public abstract class UnixCommands implements Commands, UnixPathsMixin {
     public byte[] execute(CommandInput input) throws CommandExecutionException {
         final StringJoiner joiner = new StringJoiner(" ").add(input.line());
         Optional.ofNullable(input.args()).ifPresent(args -> args.forEach(joiner::add));
+        //TODO: For windows, we need to format the path to be platform agnostic, but not for the config. We also need
+        // test cases for OTF to make sure the compatibility when crossing platforms.
         return device.execute(CommandInput.builder()
                 .workingDirectory(input.workingDirectory())
                 .line("sh")

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -61,7 +61,7 @@ public abstract class UnixCommands implements Commands, UnixPathsMixin {
         return device.execute(CommandInput.builder()
                 .workingDirectory(input.workingDirectory())
                 .line("sh")
-                .addArgs("-c", formatToUnixPath(joiner.toString()))
+                .addArgs("-c", joiner.toString())
                 .input(input.input())
                 .timeout(input.timeout())
                 .build());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The formatting is only needed for path originating for windows-unix cross-platform compatibility, thus it should not be placed in the execute command which further formats the configs. The configs are required for the local deployment.

We remove the formatting right now to unblock the local deployment with configs, but will add it back when it only format the path and the OTF have corresponding test cases in the future. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
