### PR TITLE
chore: add workflow to check binary compatibility

### DIFF
--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -1,0 +1,69 @@
+#  Copyright Amazon.com Inc. or its affiliates.
+#  SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import xml.etree.ElementTree as ET
+
+from agithub.GitHub import GitHub
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=argparse.FileType('r'), help='Input file to parse')
+    parser.add_argument('--token', type=str, help='GitHub token')
+    args = parser.parse_args()
+
+    file = args.input
+
+    my_body_dedupe = "Produced by binaryCompatability.py"
+    body = f"Binary incompatibility detected for commit {os.getenv('GITHUB_SHA')}.\n" \
+           f" See the uploaded artifacts from the action for details. You must bump the version number.\n\n"
+
+    incompatible = False
+    tree = ET.parse(file)
+    for clazz in tree.getroot().findall("./classes/class"):
+        any_incompatible = False
+        body += f"{clazz.attrib['fullyQualifiedName']} is "
+        if clazz.attrib['binaryCompatible'] == "false":
+            body += "binary incompatible"
+            incompatible = True
+            any_incompatible = True
+        if clazz.attrib['sourceCompatible'] == "false":
+            if any_incompatible:
+                body += " and is "
+            body += "source incompatible"
+            any_incompatible = True
+        if any_incompatible:
+            body += f" because of " \
+                    f"{', '.join([x.text for x in clazz.findall('compatibilityChanges/compatibilityChange')])}"
+        else:
+            body += "fully compatible"
+        body += "\n"
+    body += "\n" + my_body_dedupe
+
+    token = args.token
+    pr = json.load(open(os.getenv("GITHUB_EVENT_PATH"), 'r'))["pull_request"]["number"]
+
+    gh = GitHub(token=token)
+    existing_comments = gh.repos[os.getenv("GITHUB_REPOSITORY")].issues[pr].comments.get()
+    if existing_comments[0] == 200:
+        existing_comments = list(filter(lambda i: my_body_dedupe in i["body"], existing_comments[1]))
+    else:
+        existing_comments = []
+
+    if existing_comments:
+        comment_id = existing_comments[0]["id"]
+        if incompatible:
+            updated_issue = gh.repos[os.getenv("GITHUB_REPOSITORY")].issues.comments[comment_id].patch(body={"body": body})
+            print(updated_issue, flush=True)
+        else:
+            gh.repos[os.getenv("GITHUB_REPOSITORY")].issues.comments[comment_id].delete()
+    elif incompatible:
+        issue = gh.repos[os.getenv("GITHUB_REPOSITORY")].issues[pr].comments.post(body={"body": body})
+        print(issue, flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -9,6 +9,13 @@ import xml.etree.ElementTree as ET
 from agithub.GitHub import GitHub
 
 
+def findall_recursive(node, element):
+    for item in node.findall(element):
+        yield item
+    for item in list(node):
+        yield from findall_recursive(item, element)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--input', type=argparse.FileType('r'), help='Input file to parse')
@@ -37,7 +44,7 @@ def main():
             any_incompatible = True
         if any_incompatible:
             body += f" because of " \
-                    f"{', '.join([x.text for x in clazz.findall('compatibilityChanges/compatibilityChange')])}"
+                    f"{', '.join({x.text for x in findall_recursive(clazz, 'compatibilityChanges/compatibilityChange')})}"
         else:
             body += "fully compatible"
         body += "\n"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.sha }}
-          path: 'gson-old-japicmp'
+          path: 'otf-old-japicmp'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - name: Build HEAD
         run: |
-          cd gson-old-japicmp
+          cd otf-old-japicmp
           # Init Submodule
           git submodule update --init
           # Maven process resources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,14 @@ jobs:
           git submodule update --init
           # Maven process resources
           mvn -U -ntp clean process-resources
+          mvn -U -ntp clean package
       - name: Check binary compatibility
         id: check-compatibility
-        run: |
-          mvn --batch-mode --fail-at-end --no-transfer-progress package japicmp:cmp -DskipTests
-        
+        run: >-
+          mvn -ntp japicmp:cmp -DskipTests &&
+          pip3 -q install agithub &&
+          python3 .github/scripts/binaryCompatibility.py --input aws-greengrass-testing-standalone/target/japicmp/default-cli.xml --token "${{ github.token }}"
+        if: github.event_name == 'pull_request' && matrix.os == 'Linux'
 
   uat-linux:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,10 @@ jobs:
           git submodule update --init
           # Maven process resources
           mvn -U -ntp clean process-resources
-          mvn -U -ntp clean package
       - name: Check binary compatibility
         id: check-compatibility
         run: >-
-          mvn -ntp japicmp:cmp -DskipTests &&
+          mvn --batch-mode --fail-at-end clean package japicmp:cmp -DskipTests &&
           pip3 -q install agithub &&
           python3 .github/scripts/binaryCompatibility.py --input aws-greengrass-testing-standalone/target/japicmp/default-cli.xml --token "${{ github.token }}"
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,12 @@ jobs:
           pip3 -q install agithub &&
           python3 .github/scripts/binaryCompatibility.py --input aws-greengrass-testing-standalone/target/japicmp/default-cli.xml --token "${{ github.token }}"
         if: github.event_name == 'pull_request'
+      - name: Upload Compatibility Report
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: Binary Compatibility Report
+          path: aws-greengrass-testing-standalone/target/japicmp/default-cli.html
+        if: github.event_name == 'pull_request'
 
   uat-linux:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,44 @@ jobs:
           # Use a unique name for the report and comment
           report_name: Unit Tests Coverage Report for aws-greengrass-testing-platform-pillbox
 
+  check-binary-compatability:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: 'gson-old-japicmp'
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build HEAD
+        run: |
+          cd gson-old-japicmp
+          # Init Submodule
+          git submodule update --init
+          # Maven process resources
+          mvn -U -ntp clean process-resources
+          # Set dummy version
+          mvn --batch-mode --no-transfer-progress org.codehaus.mojo:versions-maven-plugin:2.11.0:set -DnewVersion=JAPICMP-OLD
+          # Install artifacts with dummy version in local repository; used later by Maven plugin for comparison
+          mvn --batch-mode --no-transfer-progress install -DskipTests
+      - name: Checkout new commit
+        uses: actions/checkout@v2
+      - name: Build new commit
+        run: |
+          # Init Submodule
+          git submodule update --init
+          # Maven process resources
+          mvn -U -ntp clean process-resources
+      - name: Check binary compatibility
+        id: check-compatibility
+        run: |
+          mvn --batch-mode --fail-at-end --no-transfer-progress package japicmp:cmp -DskipTests
+        
 
   uat-linux:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           mvn -ntp japicmp:cmp -DskipTests &&
           pip3 -q install agithub &&
           python3 .github/scripts/binaryCompatibility.py --input aws-greengrass-testing-standalone/target/japicmp/default-cli.xml --token "${{ github.token }}"
-        if: github.event_name == 'pull_request' && matrix.os == 'Linux'
+        if: github.event_name == 'pull_request'
 
   uat-linux:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,35 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>0.14.3</version>
+                <configuration>
+                    <oldVersion>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <!-- This is set by the GitHub workflow -->
+                            <version>JAPICMP-OLD</version>
+                        </dependency>
+                    </oldVersion>
+                    <newVersion>
+                        <file>
+                            <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+                        </file>
+                    </newVersion>
+                    <parameter>
+                        <onlyModified>true</onlyModified>
+                        <includes>
+                            <include>com.aws.greengrass.*</include>
+                        </includes>
+                        <includeExclusively>true</includeExclusively>
+                        <accessModifier>public</accessModifier>
+                        <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
         <extensions>
             <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
-                <version>0.14.3</version>
+                <version>0.17.1</version>
                 <configuration>
                     <oldVersion>
                         <dependency>
@@ -157,6 +157,7 @@
                             <artifactId>${project.artifactId}</artifactId>
                             <!-- This is set by the GitHub workflow -->
                             <version>JAPICMP-OLD</version>
+                            <type>${project.packaging}</type>
                         </dependency>
                     </oldVersion>
                     <newVersion>
@@ -172,6 +173,7 @@
                         <includeExclusively>true</includeExclusively>
                         <accessModifier>public</accessModifier>
                         <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+                        <ignoreMissingClasses>true</ignoreMissingClasses>
                     </parameter>
                 </configuration>
             </plugin>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use [japicmp](https://github.com/siom79/japicmp) (Apache-2 licensed) to identify binary incompatible changes between pull request base and new changes; 

The workflow will: 
1. Check out the pull request base and install it to local maven repository. 
2. Checkout the pull request head, build it and compare the build artifact with 1.
3. Using a Python script it will comment our your PR if there are any incompatibilities. 

**Why is this change necessary:**

**How was this change tested:**
Tested by creating a PR that is breaking binary compatibility: https://github.com/aws-greengrass/aws-greengrass-testing/pull/189

Can see the notification message as: 
~~~
Binary incompatibility detected for commit https://github.com/aws-greengrass/aws-greengrass-testing/commit/c0593a27463ac1fd3893ffaba150f8e9905b753f.
See the uploaded artifacts from the action for details. You must bump the version number.

com.aws.greengrass.testing.api.device.Device is binary incompatible and is source incompatible because of METHOD_REMOVED

Produced by binaryCompatability.py
~~~
Also, verified the binary compatibility report is uploaded to server.
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
