### PR TITLE
chore: add secret scan workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,27 @@ jobs:
           # Use a unique name for the report and comment
           report_name: Unit Tests Coverage Report for aws-greengrass-testing-platform-pillbox
 
+  scan-for-secrets:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Git Secrets
+        run: |
+          cd ~
+          git clone https://github.com/awslabs/git-secrets.git && cd git-secrets
+          sudo make install
+          echo "Git-secrets installation completed"
+          git secrets --register-aws --global
+          echo "Added aws secret templates"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Git Secrets
+        run: |
+          git secrets --scan
+          echo "Repository scan completed"
+      - name: Print remediation message
+        if: failure()
+        run: echo "git secrets found potential leaked credentials. If ANY credentials were committed, they MUST be immediately revoked."
 
   uat-linux:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'}}

--- a/aws-greengrass-testing-api/src/test/java/com/aws/greengrass/testing/api/ScenarioTestRunsTest.java
+++ b/aws-greengrass-testing-api/src/test/java/com/aws/greengrass/testing/api/ScenarioTestRunsTest.java
@@ -17,5 +17,6 @@ public class ScenarioTestRunsTest {
         TestRun testRun = TestRun.builder().name("test_name").build();
         testRuns.track(testRun);
         assertEquals(1, testRuns.tracking().size());
+        System.out.println("AWS_ACCESS_KEY_ID=ASIAUEYP5EHZYEXAMPLE");
     }
 }

--- a/aws-greengrass-testing-api/src/test/java/com/aws/greengrass/testing/api/ScenarioTestRunsTest.java
+++ b/aws-greengrass-testing-api/src/test/java/com/aws/greengrass/testing/api/ScenarioTestRunsTest.java
@@ -17,6 +17,5 @@ public class ScenarioTestRunsTest {
         TestRun testRun = TestRun.builder().name("test_name").build();
         testRuns.track(testRun);
         assertEquals(1, testRuns.tracking().size());
-        System.out.println("AWS_ACCESS_KEY_ID=ASIAUEYP5EHZYEXAMPLE");
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a workflow to scan secret by using [git-secret](https://github.com/awslabs/git-secrets). 

**Why is this change necessary:**

**How was this change tested:**
Tested by manually committed aws credential:  https://github.com/aws-greengrass/aws-greengrass-testing/actions/runs/4010787721/jobs/6887677326

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
