### PR TITLE
fix: retry gg local cli deployment status command in case of exceptions

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.features;
 
 import com.aws.greengrass.testing.api.ComponentPreparationService;
+import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.model.ScenarioContext;
 import com.aws.greengrass.testing.model.TestContext;
@@ -96,15 +97,20 @@ public class GreengrassCliSteps {
 
     @VisibleForTesting
     String getLocalDeploymentStatus() {
-        String deploymentId = scenarioContext.get(LOCAL_DEPLOYMENT_ID);
-        String response = platform.commands().executeToString(CommandInput.builder()
-                .line(testContext.installRoot().resolve("bin").resolve("greengrass-cli").toString())
-                .addAllArgs(Arrays.asList("deployment", "status", "--deploymentId", deploymentId))
-                .build());
-        LOGGER.debug(String.format("deployment status response received for deployment ID %s is %s",
-                deploymentId, response));
-        String[] responseArray = response.split(":");
-        return responseArray[responseArray.length - 1].trim();
+        try {
+            String deploymentId = scenarioContext.get(LOCAL_DEPLOYMENT_ID);
+            String response = platform.commands().executeToString(CommandInput.builder()
+                    .line(testContext.installRoot().resolve("bin").resolve("greengrass-cli").toString())
+                    .addAllArgs(Arrays.asList("deployment", "status", "--deploymentId", deploymentId))
+                    .build());
+            LOGGER.debug(String.format("deployment status response received for deployment ID %s is %s",
+                    deploymentId, response));
+            String[] responseArray = response.split(":");
+            return responseArray[responseArray.length - 1].trim();
+        } catch (CommandExecutionException e) {
+            LOGGER.info("Exception occurred while getting the deployment status. Will try again", e);
+        }
+        return "";
     }
 
     private boolean isComponentInState(String componentName, String componentStatus) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Sometimes, GG throws access denied exceptions such as the following, when Greengrass local cli command is run.

```
Error: 1.295 [otf-1.1.0-SNAPSHOT] [] [gg-923baeaa8de3ef55836b] [ERROR] greengrass/features/log-manager-1.feature - Failed at step: 'the local Greengrass deployment is SUCCEEDED on the device after 180 seconds'
com.aws.greengrass.testing.api.device.exception.CommandExecutionException: May 30, 2023 11:40:50 PM software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection$1 onProtocolMessage
WARNING: AccessDenied to event stream RPC server
java.lang.RuntimeException: Unable to create ipc client
	at com.aws.greengrass.cli.adapter.impl.NucleusAdapterIpcClientImpl.getIpcClient(NucleusAdapterIpcClientImpl.java:490)
```

This change ignores such exceptions and retries the command until it is succeeded.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
