### PR TITLE
fix: gracefully stop Nucleus instead of killing

### DIFF
--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/Commands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/Commands.java
@@ -7,12 +7,10 @@ package com.aws.greengrass.testing.platform;
 
 import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
-import com.aws.greengrass.testing.platform.NucleusInstallationParameters;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
 public interface Commands {
     byte[] execute(CommandInput input) throws CommandExecutionException;
@@ -27,6 +25,12 @@ public interface Commands {
 
     default void killAll(int pid) throws CommandExecutionException {
         kill(findDescendants(pid));
+    }
+
+    void sigterm(List<Integer> processIds) throws CommandExecutionException;
+
+    default void sigtermAll(int pid) throws CommandExecutionException {
+        sigterm(findDescendants(pid));
     }
 
     void installNucleus(NucleusInstallationParameters installationParameters) throws CommandExecutionException;

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/UnixCommands.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.testing.api.device.local.LocalDevice;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.api.device.model.PlatformOS;
 import com.aws.greengrass.testing.api.model.PillboxContext;
-import com.aws.greengrass.testing.platform.NucleusInstallationParameters;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -109,6 +107,16 @@ public abstract class UnixCommands implements Commands, UnixPathsMixin {
                     .map(i -> Integer.toString(i))
                     .collect(Collectors.joining(" ")))
             .build());
+        LOGGER.debug("Output of kill command : " + output);
+    }
+
+    @Override
+    public void sigterm(List<Integer> processIds) throws CommandExecutionException {
+        String output = executeToString(CommandInput.builder()
+                .line("kill -15 " + processIds.stream()
+                        .map(i -> Integer.toString(i))
+                        .collect(Collectors.joining(" ")))
+                .build());
         LOGGER.debug("Output of kill command : " + output);
     }
 

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsCommands.java
@@ -10,14 +10,12 @@ import com.aws.greengrass.testing.api.device.exception.CommandExecutionException
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.platform.Commands;
 import com.aws.greengrass.testing.platform.NucleusInstallationParameters;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.StringJoiner;
@@ -82,6 +80,12 @@ public class WindowsCommands implements Commands {
                 .build());
         // Command to remove it as System service
         execute(CommandInput.of("sc delete greengrass"));
+    }
+
+    @Override
+    public void sigterm(List<Integer> processIds) throws CommandExecutionException {
+        execute(CommandInput.builder().line("taskkill /PID " + processIds.stream().map(i -> Integer.toString(i))
+                .collect(Collectors.joining(" /PID "))).build());
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add sigterm command and uses it when stopping Greengrass rather than sigkill which will not give Greengrass time to properly shutdown and cleanup.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
