### PR TITLE
fix: cleanup core device and deployments after testing

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/RegistrationSteps.java
@@ -5,7 +5,6 @@
 
 package com.aws.greengrass.testing.features;
 
-import com.aws.greengrass.testing.DefaultGreengrass;
 import com.aws.greengrass.testing.api.ParameterValues;
 import com.aws.greengrass.testing.api.model.ProxyConfig;
 import com.aws.greengrass.testing.model.RegistrationContext;
@@ -17,6 +16,7 @@ import com.aws.greengrass.testing.modules.exception.ModuleProvisionException;
 import com.aws.greengrass.testing.modules.model.AWSResourcesContext;
 import com.aws.greengrass.testing.platform.Platform;
 import com.aws.greengrass.testing.resources.AWSResources;
+import com.aws.greengrass.testing.resources.greengrass.GreengrassCoreDeviceSpec;
 import com.aws.greengrass.testing.resources.iam.IamLifecycle;
 import com.aws.greengrass.testing.resources.iam.IamRole;
 import com.aws.greengrass.testing.resources.iam.IamRoleSpec;
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import io.cucumber.guice.ScenarioScoped;
 import io.cucumber.java.en.Given;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.utils.IoUtils;
 
 import java.io.IOException;
@@ -158,6 +156,7 @@ public class RegistrationSteps {
     IotThingSpec getThingSpec(String csrPath, String thingGroupName,
                               Optional<IamRole> optionalIamRole) throws IOException {
         // TODO: move this into iot steps.
+        resources.create(GreengrassCoreDeviceSpec.builder().thingName(testContext.coreThingName()).build());
         return resources.create(IotThingSpec.builder()
                 .thingName(testContext.coreThingName())
                 .addThingGroups(IotThingGroupSpec.of(thingGroupName))

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassCoreDeviceModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassCoreDeviceModel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.resources.greengrass;
+
+import com.aws.greengrass.testing.api.model.TestingModel;
+import com.aws.greengrass.testing.resources.AWSResource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.immutables.value.Value;
+import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
+import software.amazon.awssdk.services.greengrassv2.model.DeleteCoreDeviceRequest;
+import software.amazon.awssdk.services.greengrassv2.model.GreengrassV2Exception;
+
+@TestingModel
+@Value.Immutable
+interface GreengrassCoreDeviceModel extends AWSResource<GreengrassV2Client> {
+    Logger LOGGER = LogManager.getLogger(GreengrassCoreDevice.class);
+
+    String thingName();
+
+    @Override
+    default void remove(GreengrassV2Client client) {
+        try {
+            client.deleteCoreDevice(DeleteCoreDeviceRequest.builder()
+                    .coreDeviceThingName(thingName())
+                    .build());
+        } catch (GreengrassV2Exception e) {
+            LOGGER.warn("Could not delete core device {}", thingName(), e);
+        }
+    }
+}

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassCoreDeviceSpecModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassCoreDeviceSpecModel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.resources.greengrass;
+
+import com.aws.greengrass.testing.api.model.TestingModel;
+import com.aws.greengrass.testing.resources.AWSResources;
+import com.aws.greengrass.testing.resources.ResourceSpec;
+import org.immutables.value.Value;
+import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
+
+import javax.annotation.Nullable;
+
+@TestingModel
+@Value.Immutable
+interface GreengrassCoreDeviceSpecModel extends ResourceSpec<GreengrassV2Client, GreengrassCoreDevice> {
+    @Nullable
+    String thingName();
+
+    @Override
+    @Nullable
+    GreengrassCoreDevice resource();
+
+    @Override
+    default GreengrassCoreDeviceSpec create(GreengrassV2Client client, AWSResources resources) {
+        return GreengrassCoreDeviceSpec.builder()
+                .from(this)
+                .created(true)
+                .resource(GreengrassCoreDevice.builder()
+                        .thingName(thingName())
+                        .build())
+                .build();
+    }
+}

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassDeploymentModel.java
@@ -12,12 +12,10 @@ import org.apache.logging.log4j.Logger;
 import org.immutables.value.Value;
 import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 import software.amazon.awssdk.services.greengrassv2.model.CancelDeploymentRequest;
-import software.amazon.awssdk.services.greengrassv2.model.DeleteCoreDeviceRequest;
-import software.amazon.awssdk.services.greengrassv2.model.GreengrassV2Exception;
+import software.amazon.awssdk.services.greengrassv2.model.DeleteDeploymentRequest;
 import software.amazon.awssdk.services.greengrassv2.model.ValidationException;
 
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 @TestingModel
@@ -32,23 +30,19 @@ interface GreengrassDeploymentModel extends AWSResource<GreengrassV2Client> {
 
     @Override
     default void remove(GreengrassV2Client client) {
-        Optional.ofNullable(thingNames()).ifPresent(thingNames -> {
-            thingNames.forEach(thingName -> {
-                try {
-                    client.deleteCoreDevice(DeleteCoreDeviceRequest.builder()
-                            .coreDeviceThingName(thingName)
-                            .build());
-                } catch (GreengrassV2Exception e) {
-                    LOGGER.warn("Could not delete core device {}", thingName);
-                }
-            });
-        });
         try {
             client.cancelDeployment(CancelDeploymentRequest.builder()
                     .deploymentId(deploymentId())
                     .build());
         } catch (ValidationException ve) {
             LOGGER.warn("Could not cancel deployment {}", deploymentId());
+        }
+        try {
+            client.deleteDeployment(DeleteDeploymentRequest.builder()
+                    .deploymentId(deploymentId())
+                    .build());
+        } catch (ValidationException ve) {
+            LOGGER.warn("Could not delete deployment {}", deploymentId());
         }
     }
 }

--- a/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
+++ b/aws-greengrass-testing-resources/aws-greengrass-testing-resources-greengrass/src/main/java/com/aws/greengrass/testing/resources/greengrass/GreengrassV2Lifecycle.java
@@ -30,7 +30,7 @@ import javax.inject.Inject;
 public class GreengrassV2Lifecycle extends AbstractAWSResourceLifecycle<GreengrassV2Client> {
     @Inject
     public GreengrassV2Lifecycle(GreengrassV2Client client) {
-        super(client, GreengrassComponentSpec.class, GreengrassDeploymentSpec.class);
+        super(client, GreengrassComponentSpec.class, GreengrassDeploymentSpec.class, GreengrassCoreDeviceSpec.class);
     }
 
     public GreengrassV2Lifecycle() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently the core device is only deleted if there's a deployment associated with it. This change now has us always attempt to delete the core device which we assume that we created when creating the iot thing.

This change also deletes the deployment instead of just canceling it.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
