### PR TITLE
feat(features-api): extend FileSteps and tune GreengrassCliSteps

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/FileSteps.java
@@ -115,6 +115,30 @@ public class FileSteps {
     }
 
     /**
+     * File contains content at least N times after a duration.
+     *
+     * @param file file on a {@link Device}
+     * @param contents file contents
+     * @param times how many times contents should be present in file
+     * @param value integer value for a duration
+     * @param unit {@link TimeUnit} duration
+     * @throws InterruptedException thread was interrupted while waiting
+     */
+    @Then("the file {word} on device contains {string} at least {int} times within {int} {word}")
+    public void containsTimeout(String file, String contents, int times, int value, String unit)
+                    throws InterruptedException {
+        checkFileExists(file);
+        TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
+        boolean found = waits.untilTrue(() ->
+                hasNMatches(platform.files().readString(testContext.installRoot().resolve(file)), contents, times),
+            value, timeUnit);
+
+        if (!found) {
+            throw new IllegalStateException("file " + file + " did not contain " + contents);
+        }
+    }
+
+    /**
      * Verifies that a component log file contains the contents within an interval.
      *
      * @param component name of the component log
@@ -133,7 +157,24 @@ public class FileSteps {
     }
 
     /**
-     * Verifies that a compoennt log does not contain a line.
+     * Verifies that a component log file contains the contents within an interval.
+     *
+     * @param component name of the component log
+     * @param line contents to validate
+     * @param times how many times contents should be present in file
+     * @param value number of units
+     * @param unit specific {@link TimeUnit}
+     * @throws InterruptedException throws when thread is interrupted
+     */
+    @Then("the {word} log on the device contains the line {string} at least {int} times within {int} {word}")
+    public void logContains(String component, String line, int times, int value, String unit)
+                    throws InterruptedException {
+        String componentPath = "logs/" + component + ".log";
+        containsTimeout(componentPath, line, times, value, unit);
+    }
+
+    /**
+     * Verifies that a component log does not contain a line.
      *
      * @param component name of the component log
      * @param line value the log file should not contain
@@ -241,5 +282,17 @@ public class FileSteps {
                 platform.commands().startGreengrassService();
             }
         }
+    }
+
+    private static boolean hasNMatches(final String haystack, final String needle, int minMatches) {
+        for (int startIndex = 0; minMatches > 0; minMatches--) {
+            int foundIndex = haystack.indexOf(needle, startIndex);
+            if (foundIndex < startIndex) {
+                return false;
+            }
+            startIndex = foundIndex + 1;
+        }
+
+        return true;
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/GreengrassCliSteps.java
@@ -83,16 +83,18 @@ public class GreengrassCliSteps {
     /**
      * Verify status of local deployment.
      * @param status desired status
-     * @param timeout timeout in seconds
+     * @param value integer value duration
+     * @param unit {@link TimeUnit} for the duration
      * @throws InterruptedException {@link InterruptedException}
      */
-    @And("the local Greengrass deployment is {word} on the device after {int} seconds")
-    public void verifyLocalDeployment(String status, int timeout) throws InterruptedException {
+    @And("the local Greengrass deployment is {word} on the device after {int} {word}")
+    public void verifyLocalDeployment(String status, int value, String unit) throws InterruptedException {
         List<String> terminalStatuses = new ArrayList<>();
         terminalStatuses.add("SUCCEEDED");
         terminalStatuses.add("FAILED");
+        TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
         waitSteps.untilTerminal(() -> this.getLocalDeploymentStatus(), status::equals,
-                terminalStatuses::contains, timeout, TimeUnit.SECONDS);
+                terminalStatuses::contains, value, timeUnit);
     }
 
     @VisibleForTesting

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/features/GreengrassCliStepsTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/features/GreengrassCliStepsTest.java
@@ -76,10 +76,10 @@ public class GreengrassCliStepsTest {
     @Test
     void GIVEN_a_local_deployment_happened_WHEN_verify_it_THEN_it_reaches_the_expected_status_after_n_seconds() {
         Mockito.doReturn("SUCCEEDED").when(greengrassCliSteps).getLocalDeploymentStatus();
-        assertDoesNotThrow(() -> greengrassCliSteps.verifyLocalDeployment("SUCCEEDED", 30));
+        assertDoesNotThrow(() -> greengrassCliSteps.verifyLocalDeployment("SUCCEEDED", 30, "seconds"));
 
         Mockito.doReturn("FAILED").when(greengrassCliSteps).getLocalDeploymentStatus();
-        assertDoesNotThrow(() -> greengrassCliSteps.verifyLocalDeployment("FAILED", 30));
+        assertDoesNotThrow(() -> greengrassCliSteps.verifyLocalDeployment("FAILED", 30, "seconds"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Extend FileSteps to be able waiting for at least N occurrences of string in file
- tune verifyLocalDeployment() by receive time units

**Why is this change necessary:**
When Nucleus is restarted we need to check Bridge is connected to a local broker before continue but that report to log files event second time.
verifyLocalDeployment at the moment differs from other deployment waiting step by accept only seconds instead of time units

**How was this change tested:**
By using in scenarios

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
