### PR TITLE
feat: add support for multi-platform manifests

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/ClasspathComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/ClasspathComponentPreparationService.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.testing.api.model.ComponentOverrides;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.JacksonModule;
+import com.aws.greengrass.testing.platform.PlatformResolver;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -18,12 +19,13 @@ import javax.inject.Named;
 public class ClasspathComponentPreparationService extends RecipeComponentPreparationService {
     @Inject
     public ClasspathComponentPreparationService(
+            PlatformResolver platformResolver,
             AWSResources resources,
             @Named(JacksonModule.YAML) ObjectMapper mapper,
             TestContext testContext,
             GreengrassContext greengrassContext,
             ComponentOverrides overrides) {
-        super(ClasspathComponentPreparationService.class::getResourceAsStream,
+        super(platformResolver, ClasspathComponentPreparationService.class::getResourceAsStream,
                 resources, mapper, testContext, greengrassContext, overrides);
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/FileComponentPreparationService.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.testing.api.model.ComponentOverrides;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
 import com.aws.greengrass.testing.modules.JacksonModule;
+import com.aws.greengrass.testing.platform.PlatformResolver;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -20,12 +21,13 @@ import javax.inject.Named;
 public class FileComponentPreparationService extends RecipeComponentPreparationService {
     @Inject
     public FileComponentPreparationService(
+            PlatformResolver platformResolver,
             AWSResources resources,
             @Named(JacksonModule.YAML) ObjectMapper mapper,
             TestContext testContext,
             GreengrassContext greengrassContext,
             ComponentOverrides overrides) {
-        super(value -> Files.newInputStream(Paths.get(value)),
+        super(platformResolver, value -> Files.newInputStream(Paths.get(value)),
                 resources, mapper, testContext, greengrassContext, overrides);
     }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/GreengassPlatform.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/GreengassPlatform.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.aws.greengrass.testing.platform.PlatformResolver.ALL_KEYWORD;
+import static com.aws.greengrass.testing.platform.PlatformResolver.ARCHITECTURE_KEY;
+import static com.aws.greengrass.testing.platform.PlatformResolver.OS_KEY;
+import static com.aws.greengrass.testing.platform.PlatformResolver.WILDCARD;
+
+/**
+ * <p>Class representing a Greengass platform map.
+ * A platform map is a set of key/value pairs for matching against arbitrary keys.
+ * Some well defined keys do exist, but is irrelevant for Manifest data model.</p>
+ *
+ * <p>The value is a match expression, as follows:
+ *     <ul>
+ *         <li>name=stringValue - where stringValue beings with letter or digit - perform an exact match.</li>
+ *         <li>name=/regex/ - match string against regular expression string.</li>
+ *         <li>name="*" - match string against anything, including missing value.</li>
+ *     </ul>
+ */
+public class GreengassPlatform extends HashMap<String,String> {
+    // GreengassPlatform with no key/value pairs
+    private static final GreengassPlatform EMPTY = new GreengassPlatform();
+
+    /**
+     * Retrieve specified field. Use wildcard if field does not exist or empty string.
+     * @param name Name of field
+     * @return Field, substituting wildcard as needed.
+     */
+    public String getFieldOrWild(String name) {
+        Object o = get(name);
+        if (o == null || ((String)o).length() == 0) {
+            return WILDCARD;
+        } else {
+            return (String)o;
+        }
+    }
+
+    private <T extends Enum<T>> T getEnum(String name, Function<String, T> transform) {
+        return transform.apply(getFieldOrWild(name));
+    }
+
+    public OS getOs() {
+        return getEnum(OS_KEY, OS::getOS);
+    }
+
+    public Architecture getArchitecture() {
+        return getEnum(ARCHITECTURE_KEY, Architecture::getArch);
+    }
+
+    /**
+     * Retrieve OS, or Wildcard if OS not specified.
+     *
+     * @return OS as a string with expected default.
+     */
+    public String getOsField() {
+        return getFieldOrWild(OS_KEY);
+    }
+
+    /**
+     * Retrieve Architecture, or Wildcard if Architecture not specified.
+     *
+     * @return Architecture as a string with expected default.
+     */
+    public String getArchitectureField() {
+        return getFieldOrWild(ARCHITECTURE_KEY);
+    }
+
+    /**
+     * Backward compatibility only for transition: Set of OSes.
+     */
+    public enum OS {
+        ALL(ALL_KEYWORD),
+        WINDOWS("windows"),
+        LINUX("linux"),
+        DARWIN("darwin"),
+        MACOS("macos"),
+        UNKNOWN("unknown");
+
+        private final String name;
+
+        OS(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Backward compatibility only for transition: Convert string to enum value.
+         * @param value String value to convert
+         * @return enum value
+         */
+        public static OS getOS(String value) {
+            // "any" and "all" keyword are both accepted in recipe.
+            if (value == null || "any".equalsIgnoreCase(value) || "all".equalsIgnoreCase(value) || "*".equals(value)) {
+                return OS.ALL;
+            }
+
+            for (OS os : values()) {
+                if (os.getName().equals(value)) {
+                    return os;
+                }
+            }
+
+            // return UNKNOWN instead of throw exception. This is to keep backwards compatibility when
+            // cloud recipe has more supported platform than local.
+            return OS.UNKNOWN;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * Backward compatibility only for transition: Set of Architectures.
+     */
+    //@Getter
+    //@AllArgsConstructor
+    //@Deprecated
+    public enum Architecture {
+        ALL(ALL_KEYWORD),
+        AMD64("amd64"),
+        ARM("arm"),
+        AARCH64("aarch64"),
+        X86("x86"),
+        UNKNOWN("unknown");
+
+        private final String name;
+
+
+        Architecture(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Backward compatibility only for transition: Convert string to enum value.
+         * @param value String value to convert
+         * @return enum value
+         */
+        public static Architecture getArch(String value) {
+            if (value == null || "any".equalsIgnoreCase(value) || "all".equalsIgnoreCase(value) || "*".equals(value)) {
+                // "any" and "all" keyword are both accepted in recipe.
+                return Architecture.ALL;
+            }
+
+            for (Architecture arch : values()) {
+                if (arch.getName().equals(value)) {
+                    return arch;
+                }
+            }
+            return Architecture.UNKNOWN;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * This is to help migration to new GreengassPlatform class.
+     */
+    //@Deprecated
+    public static final class GreengassPlatformBuilder {
+        private final Map<String, String> platform = new HashMap<String,String>();
+
+        /**
+         * Sets OS.
+         *
+         * @param value the value of OS.
+         */
+        public GreengassPlatformBuilder os(OS value) {
+            if (value == OS.ALL) {
+                return add(OS_KEY, "*");
+            } else {
+                return add(OS_KEY, value.name);
+            }
+        }
+
+        /**
+         * Sets arhitecture.
+         *
+         * @param value the value of arhitecture
+         */
+        public GreengassPlatformBuilder architecture(Architecture value) {
+            if (value == Architecture.ALL) {
+                return add(ARCHITECTURE_KEY, "*");
+            } else {
+                return add(ARCHITECTURE_KEY, value.name);
+            }
+        }
+
+        /**
+         * Sets additional property.
+         *
+         * @param name the name of a property
+         * @param value the value of a property
+         */
+        public GreengassPlatformBuilder add(String name, String value) {
+            if (value != null) {
+                platform.put(name, value);
+            }
+            return this;
+        }
+
+        /**
+         * Produce platform instance.
+         */
+        public GreengassPlatform build() {
+            GreengassPlatform p = new GreengassPlatform();
+            p.putAll(this.platform);
+            return p;
+        }
+    }
+
+    public static GreengassPlatformBuilder builder() {
+        return new GreengassPlatformBuilder();
+    }
+}

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/GreengassPlatformHelper.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/GreengassPlatformHelper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static com.aws.greengrass.testing.platform.PlatformResolver.ARCHITECTURE_KEY;
+import static com.aws.greengrass.testing.platform.PlatformResolver.OS_KEY;
+import static com.aws.greengrass.testing.platform.PlatformResolver.WILDCARD;
+
+public final class GreengassPlatformHelper {
+
+    // this test exists so to allow future extension, a platform label should not start with special characters
+    private static final Pattern SIMPLE_LABEL = Pattern.compile("^[a-zA-Z0-9]");
+
+    private GreengassPlatformHelper() {
+    }
+
+    /**
+     * find best match from a list of recipes.
+     *
+     * @param targetPlatform Platform attributes to test against (usually the actual platform of the device).
+     * @param manifestList   A list of recipe manifests.
+     * @return first matching manifest.
+     */
+    public static Optional<Map<String, Object>> findBestMatch(final Map<String, String> targetPlatform,
+                                                                   final List<Map<String, Object>> manifestList) {
+        //
+        // Manifests are listed in order of preference, so the first match is the relevant match
+        //
+        return manifestList.stream().filter(m -> isRequirementSatisfied(targetPlatform, m)).findFirst();
+    }
+
+    /**
+     * Test that the requirements section of a manifest is satisfied.
+     * @param targetPlatform GreengassPlatform to test against (usually the actual platform of the device).
+     * @param manifest Single manifest
+     * @return
+     */
+    private static boolean isRequirementSatisfied(final Map<String, String> targetPlatform,
+                                                    final Map<String, Object> manifest) {
+        //
+        // The "requirement" section of the Manifest contains a map of attribute:template
+        // Note that it is important that an attribute is permitted to be in targetPlatform but not in requirement,
+        // which will happen as we add more attributes to match against. Therefore all requirements must be
+        // satisfied, but not all target attributes need to have a requirement template.
+        //
+        GreengassPlatform platformRequirement = getPlatform(manifest);
+        if (platformRequirement == null || platformRequirement.isEmpty()) {
+            return true; // no platform is considered a wild-card
+        }
+        return platformRequirement.entrySet().stream().allMatch(e ->
+                isAttributeSatisfied(e.getKey(), targetPlatform.get(e.getKey()), e.getValue()));
+    }
+
+    /**
+     * Test a single field expression is satisfied.
+     *
+     * @param name     Attribute name (some names may change match behavior)
+     * @param label    GreengassPlatform label (as provided by target platform, null if not defined)
+     * @param template Template (a string)
+     * @return true if attribute requirement is satisfied
+     */
+    private static boolean isAttributeSatisfied(String name, String label, String template) {
+        if (template == null || template.equals(WILDCARD)) {
+            // treat null same as missing template entry.
+            // treat both as same as wildcard
+            return true;
+        }
+        if (label == null || label.length() == 0) {
+            // in all other cases, label must not be a null / missing / blank
+            // (each indicate no value)
+            return false;
+        }
+        if (template.length() >= 2 && template.startsWith("/") && template.endsWith("/")) {
+            // regular expression match, such as for alternatives
+            return label.matches(template.substring(1, template.length() - 1));
+        }
+        if (OS_KEY.equals(name) && ("all".equals(template) || "any".equals(template))) {
+            return true; // treat as wildcard
+        }
+
+        if (ARCHITECTURE_KEY.equals(name) && ("all".equals(template) || "any".equals(template))) {
+            return true; // treat as wildcard
+        }
+        // Other special symbols may be implemented here, so we permit only simple labels for platform matching
+        if (!SIMPLE_LABEL.matcher(template).lookingAt()) {
+            // reject any special labels, to allow future extension
+            // Review note, how to log?
+            return false;
+        }
+        return template.equals(label);
+    }
+
+    private static GreengassPlatform getPlatform(final Map<String, Object> manifest) {
+        String os = null;
+        String architecture = null;
+
+        Map<String, String> platform = (Map<String, String>) manifest.get("Platform");
+        if (platform != null) {
+            os = (String) platform.get(OS_KEY);
+            architecture = (String) platform.get(ARCHITECTURE_KEY);
+        }
+
+        return new GreengassPlatform.GreengassPlatformBuilder()
+            .os(GreengassPlatform.OS.getOS(os))
+            .architecture(GreengassPlatform.Architecture.getArch(architecture))
+            .build();
+    }
+}

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/PlatformModule.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/modules/PlatformModule.java
@@ -22,4 +22,10 @@ public class PlatformModule extends AbstractModule {
     static Platform providesPlatform(final Device device, final PillboxContext pillboxContext) {
         return new PlatformResolver(device, pillboxContext).resolve();
     }
+
+    @Provides
+    @ScenarioScoped
+    static PlatformResolver providesPlatformResolver(final Device device, final PillboxContext pillboxContext) {
+        return new PlatformResolver(device, pillboxContext);
+    }
 }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/ClasspathComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/ClasspathComponentPreparationServiceTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.component;
 import com.aws.greengrass.testing.api.model.ComponentOverrides;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.platform.PlatformResolver;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -19,6 +20,10 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClasspathComponentPreparationServiceTest {
+
+    @Mock
+    PlatformResolver platformResolver;
+
     @Mock
     AWSResources resources;
 
@@ -35,7 +40,8 @@ public class ClasspathComponentPreparationServiceTest {
 
     @InjectMocks
     ClasspathComponentPreparationService classpathComponentPreparationService = Mockito.spy(
-            new ClasspathComponentPreparationService(resources, mapper, testContext, greengrassContext, overrides));
+            new ClasspathComponentPreparationService(platformResolver, resources, mapper, testContext,
+                                                        greengrassContext, overrides));
 
 
     @Test

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/FileComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/FileComponentPreparationServiceTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.component;
 import com.aws.greengrass.testing.api.model.ComponentOverrides;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.platform.PlatformResolver;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -19,6 +20,9 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FileComponentPreparationServiceTest {
+
+    @Mock
+    PlatformResolver platformResolver;
 
     @Mock
     AWSResources resources;
@@ -36,7 +40,8 @@ public class FileComponentPreparationServiceTest {
 
     @InjectMocks
     FileComponentPreparationService fileComponentPreparationService = Mockito.spy(
-            new FileComponentPreparationService(resources, mapper, testContext, greengrassContext, overrides));
+            new FileComponentPreparationService(platformResolver, resources, mapper, testContext, greengrassContext,
+                                                    overrides));
 
     @Test
     void GIVEN_a_FileComponentPreparationService_class_inherits_RecipeComponentPreparationService_class_WHEN_a_FileComponentPreparationService_instance_is_initialized_THEN_it_inherit_properly() {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/RecipeComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/RecipeComponentPreparationServiceTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.testing.api.model.ComponentOverrides;
 import com.aws.greengrass.testing.api.model.TestId;
 import com.aws.greengrass.testing.model.GreengrassContext;
 import com.aws.greengrass.testing.model.TestContext;
+import com.aws.greengrass.testing.platform.PlatformResolver;
 import com.aws.greengrass.testing.resources.AWSResources;
 import com.aws.greengrass.testing.resources.greengrass.GreengrassComponent;
 import com.aws.greengrass.testing.resources.greengrass.GreengrassComponentSpec;
@@ -52,6 +53,9 @@ public class RecipeComponentPreparationServiceTest {
     GreengrassV2Lifecycle greengrassV2Lifecycle = new GreengrassV2Lifecycle();
 
     @Mock
+    PlatformResolver platformResolver;
+
+    @Mock
     TestContext testContext;
 
     @Mock
@@ -77,7 +81,7 @@ public class RecipeComponentPreparationServiceTest {
     @BeforeEach
     public void setup() {
         resourceDirectory = Paths.get(System.getProperty("user.dir"),"src", "test", "resources");
-        this.componentPreparation = Mockito.spy(new RecipeComponentPreparationService(loader,
+        this.componentPreparation = Mockito.spy(new RecipeComponentPreparationService(platformResolver, loader,
                 resources, mapper, testContext, greengrassContext, overrides));
     }
 

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: com.aws.HelloWorld
+ComponentVersion: '1.0.2'
+ComponentDescription: Hello World Cloud Component.
+ComponentPublisher: Amazon
+Manifests:
+- Platform:
+    os: windows
+  Artifacts:
+    - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-cloudcomponent.zip
+      Unarchive: ZIP
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      cmd /c echo "Hello World!"
+- Platform:
+    os: linux
+  Artifacts:
+    - URI: classpath:/greengrass/components/artifacts/aws-greengrass-testing-features-cloudcomponent.zip
+      Unarchive: ZIP
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      bash -c "echo -ne \"Hello World!\n\""

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -31,3 +31,11 @@ Feature: Testing Cloud component in Greengrass
     And I deploy the Greengrass deployment configuration to thing group
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds
+
+  @CloudDeployment @IDT
+  Scenario: As a developer, I can create a multi-platform component in Cloud and deploy it on my device
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World!" within 20 seconds

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/PlatformResolver.java
@@ -14,17 +14,46 @@ import com.aws.greengrass.testing.platform.macos.MacosPlatform;
 import com.aws.greengrass.testing.platform.windows.WindowsPlatform;
 import com.google.common.annotations.VisibleForTesting;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
 public class PlatformResolver {
+    public static final String ALL_KEYWORD = "all";
+    private static final String UNKNOWN_KEYWORD = "unknown";
+    public static final String WILDCARD = "*";
+
+    public static final String OS_KEY = "os";
+    public static final String ARCHITECTURE_KEY = "architecture";
+    public static final String ARCHITECTURE_DETAIL_KEY = "architecture.detail";
+
+
+    // Note that this is not an exhaustive list of OSes, but happens to be a set of platforms detected.
+    private static final String OS_WINDOWS = "windows";
+    private static final String OS_DARWIN = "darwin";
+    private static final String OS_LINUX = "linux";
+
+
+    // Note that this is not an exhaustive list of Architectures, but happens to be a set of platforms detected.
+    private static final String ARCH_AMD64 = "amd64";
+    private static final String ARCH_X86 = "x86";
+    private static final String ARCH_ARM = "arm";
+    private static final String ARCH_AARCH64 = "aarch64";
+
     private static final Set<String> SUPPORTED_PLATFORMS = Collections.unmodifiableSet(Stream.of(
-            "all", "any", "unix", "posix", "linux", "debian", "windows", "fedora", "ubuntu", "macos",
+            "all", "any", "unix", "posix", OS_LINUX, "debian", OS_WINDOWS, "fedora", "ubuntu", "macos",
             "raspbian", "qnx", "cygwin", "freebsd", "solaris", "sunos").collect(Collectors.toSet()));
+
+    private static final AtomicReference<Map<String, String>> DETECTED_PLATFORM =
+            new AtomicReference<>();
 
     private final Device device;
     private final PillboxContext pillboxContext;
@@ -41,11 +70,11 @@ public class PlatformResolver {
      */
     public Platform resolve() {
         final Map<String, Integer> ranks = createRanks();
-        if (ranks.containsKey("linux")) {
+        if (ranks.containsKey(OS_LINUX)) {
             return new LinuxPlatform(device, pillboxContext);
         } else if (ranks.containsKey("macos")) {
             return new MacosPlatform(device, pillboxContext);
-        } else if (ranks.containsKey("windows")) {
+        } else if (ranks.containsKey(OS_WINDOWS)) {
             return new WindowsPlatform(device, pillboxContext);
         }
         throw new PlatformResolutionException("Could not find a platform support for device: " + device.platform());
@@ -61,14 +90,14 @@ public class PlatformResolver {
         ranks.put("any", 0);
 
         if (device.platform().isWindows()) {
-            ranks.put("windows", 5);
+            ranks.put(OS_WINDOWS, 5);
         } else {
             if (device.exists("/bin/bash") || device.exists("/usr/bin/bash")) {
                 ranks.put("unix", 3);
                 ranks.put("posix", 3);
             }
             if (device.exists("/proc")) {
-                ranks.put("linux", 10);
+                ranks.put(OS_LINUX, 10);
             }
             if (device.exists("/usr/bin/apt-get")) {
                 ranks.put("debian", 11);
@@ -82,7 +111,7 @@ public class PlatformResolver {
             if (sysver.contains("ubuntu")) {
                 ranks.put("ubuntu", 20);
             }
-            if (sysver.contains("darwin") || sysver.contains("Darwin")) {
+            if (sysver.contains(OS_DARWIN) || sysver.contains("Darwin")) {
                 ranks.put("macos", 20);
             }
             if (sysver.contains("raspbian")) {
@@ -102,5 +131,84 @@ public class PlatformResolver {
             }
         }
         return ranks;
+    }
+
+    /**
+     * Get current Greengrass platform.
+     * Detect current Greengrass platform.
+     *
+     * @return Greengrass Platform key-value map
+     */
+    public Map<String, String> getCurrentPlatform() {
+        return getGreengrassPlatform();
+    }
+
+    private synchronized Map<String, String> getGreengrassPlatform() {
+        Map<String, String> detected = DETECTED_PLATFORM.get();
+        if (detected == null) {
+            detected = initializePlatform();
+            DETECTED_PLATFORM.set(detected);
+        }
+        return detected;
+    }
+
+    private Map<String, String> initializePlatform() {
+        Map<String, String> platform = new HashMap<>();
+        platform.put("os", getOSInfo());
+        platform.put("architecture", getArchInfo());
+        platform.put("architecture.detail", getArchDetailInfo());
+
+        return platform;
+    }
+
+    private String getOSInfo() {
+        if (device.platform().isWindows()) {
+            return OS_WINDOWS;
+        }
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("mac os")) {
+            return OS_DARWIN;
+        }
+        if (Files.exists(Paths.get("/proc"))) {
+            return OS_LINUX;
+        }
+        return UNKNOWN_KEYWORD;
+    }
+
+    private static String getArchInfo() {
+        String arch = System.getProperty("os.arch").toLowerCase();
+        if ("x86_64".equals(arch) || "amd64".equals(arch)) {
+            return ARCH_AMD64; // x86_64 & amd64 are same
+        }
+        if ("i386".equals(arch) || "x86".equals(arch)) {
+            return ARCH_X86;
+        }
+        if (arch.contains("arm")) {
+            return ARCH_ARM;
+        }
+        if ("aarch64".equals(arch)) {
+            return ARCH_AARCH64;
+        }
+        return UNKNOWN_KEYWORD;
+    }
+
+    private String getArchDetailInfo() {
+        if (device.platform().isWindows()) {
+            return null;
+        }
+
+        String arch = getArchInfo();
+        // Since we only can detect the architecture details for arm, only run uname -m when we are running
+        // on arm.
+        if (ARCH_ARM.equals(arch) || ARCH_AARCH64.equals(arch)) {
+            CommandInput command = CommandInput.builder().line("sh").addArgs("-c", "uname -m").build();
+            String archDetail = resolve().commands().executeToString(command).toLowerCase();
+            // TODO: "uname -m" is not sufficient to capture arch details on all platforms.
+            // Currently only return if detected arm, as required by lambda launcher.
+            if ("armv6l".equals(archDetail) || "armv7l".equals(archDetail) || "armv8l".equals(archDetail)) {
+                return archDetail;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
#209 

**Description of changes:**
TODO

**Why is this change necessary:**
We can't use recipe files with contains Platform selectors inside Manifests.
It results in not possible to provide multi-platform components without tricks.

**How was this change tested:**
New scenario added to cloudComponent.feature

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
