### PR TITLE
feat: add support for multi-platform manifests

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/PreparationServiceUtils.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/component/PreparationServiceUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+class PreparationServiceUtils {
+
+    /**
+     * Checks is artifact with schema classpath or file exists.
+     *
+     * @param uri URI to check is exist of not
+     * @return true when artifact is not classpath or file, or exists
+     * @throws IOException when IO errors occured
+     */
+    protected boolean isArtifactExists(String uri) throws IOException {
+        String[] parts = uri.split(":", 2);
+        switch (parts[0]) {
+            case "classpath":
+                InputStream stream = getClass().getResourceAsStream(parts[1]);
+                if (stream == null) {
+                    return false;
+                }
+                stream.close();
+                break;
+            case "file":
+                return Files.exists(Paths.get(parts[1]));
+            default:
+                break;
+        }
+
+        return true;
+    }
+}

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/LocalComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/LocalComponentPreparationServiceTest.java
@@ -79,6 +79,7 @@ public class LocalComponentPreparationServiceTest {
                 .when(loader).load(Mockito.any());
         Mockito.doReturn(loader)
                 .when(componentPreparation).getLoader();
+        Mockito.doReturn(true).when(componentPreparation).isArtifactExists(Mockito.any());
         Mockito.doNothing()
                 .when(componentPreparation).copyArtifactToLocalStore(Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.doNothing().when(componentPreparation).copyRecipeToLocalStore(Mockito.any(), Mockito.any(), Mockito.any());

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/RecipeComponentPreparationServiceTest.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/test/java/com.aws.greengrass.testing/component/RecipeComponentPreparationServiceTest.java
@@ -95,6 +95,7 @@ public class RecipeComponentPreparationServiceTest {
         Mockito.doReturn(MOCK_TEST_ID).when(testId).id();
         Mockito.doReturn(testId).when(testContext).testId();
         Mockito.doReturn(greengrassV2Lifecycle).when(resources).lifecycle(GreengrassV2Lifecycle.class);
+        Mockito.doReturn(true).when(componentPreparation).isArtifactExists(Mockito.any());
         Mockito.doReturn(MOCK_BUCKET_NAME).when(componentPreparation).getOrCreateBucket();
         Mockito.doReturn(MOCK_ARTIFACT_URI).when(componentPreparation)
                 .uploadArtifact(Mockito.any(), Mockito.any(), Mockito.any());

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: com.aws.HelloWorldMultiplatform
+ComponentVersion: '1.0.0'
+ComponentDescription: Hello World Multiplatform Cloud Component.
+ComponentPublisher: Amazon
+Manifests:
+- Platform:
+    os: windows
+  Artifacts:
+    - URI: "file:C:/Windows/System32/cmd.exe"
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      cmd /c echo "Hello World!"
+- Platform:
+    os: linux
+  Artifacts:
+    - URI: file:/bin/bash
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      bash -c "echo -ne \"Hello World!\n\""

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -31,3 +31,11 @@ Feature: Testing Cloud component in Greengrass
     And I deploy the Greengrass deployment configuration to thing group
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds
+
+  @CloudDeployment @IDT @OTFStable
+  Scenario: As a developer, I can create a multi-platform component in Cloud and deploy it on my device
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorldMultiplatform | classpath:/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorldMultiplatform log on the device contains the line "Hello World!" within 20 seconds

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world_multiplatform.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world_multiplatform.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: com.aws.LocalHelloWorldMultiplatform
+ComponentVersion: '1.0.0'
+ComponentDescription: Hello World Multiplatform Local Component.
+ComponentPublisher: Amazon
+Manifests:
+- Platform:
+    os: windows
+  Artifacts:
+    - URI: "file:C:/Windows/System32/cmd.exe"
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      cmd /c echo "Hello World!"
+- Platform:
+    os: linux
+  Artifacts:
+    - URI: file:/bin/bash
+      Permission:
+        Read: ALL
+        Execute: ALL
+  Lifecycle:
+    run: |
+      bash -c "echo -ne \"Hello World!\n\""

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -16,3 +16,14 @@ Feature: Testing local deployment using CLI in Greengrass
     Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
     And the aws.greengrass.LocalHelloWorld log on the device contains the line "Hello World!!" within 20 seconds
 
+  @LocalDeployment @IDT @OTFStable
+  Scenario: A multi-platform component is deployed locally using CLI
+    When I create a Greengrass deployment with components
+      | aws.greengrass.Cli | GG_CLI_VERSION |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    Then I verify greengrass-cli is available in greengrass root
+    When I create a local deployment with components
+      | com.aws.LocalHelloWorldMultiplatform | local:/greengrass/components/recipes/local_hello_world_multiplatform.yaml |
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+    And the com.aws.LocalHelloWorldMultiplatform log on the device contains the line "Hello World!" within 20 seconds


### PR DESCRIPTION
**Issue #, if available:**
#209 

**Description of changes:**
- Fix bug with Mandatory Artifacts in Manifests item
- Fixed bug with invalid split for Windows files in LocalComponentPreparationService
- Update LocalComponentPreparationService by adding check artifacts of types file or classpath is exists and filter out Manifests if contains missing artifacts
- Update RecipeComponentPreparationService by adding check artifacts of types file or classpath is exists and filter out Manifests if contains missing artifacts
- Add PreparationServiceUtils with isArtifactExists()
- Update unit tests to mirror changes
- Add components and scenarios for Cloud and Local component tests


**Why is this change necessary:**
We can't use recipe files with contains Platform selectors inside Manifests.
It results in not possible to provide multi-platform components without tricks.

**How was this change tested:**
New scenarios added to cloudComponent.feature and localdeployment.feature should be automatically tested in CI.
But I see CI do not run tests on Windows

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
