### PR TITLE
fix: remove 443 from list of blocked ports

### DIFF
--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
@@ -8,9 +8,21 @@ package com.aws.greengrass.testing.platform;
 import java.io.IOException;
 
 public abstract class NetworkUtils {
-    protected static final String[] MQTT_PORTS = {"8883", "443"};
+    protected static final String[] MQTT_PORTS = {"8883"};
 
+    /**
+     * Disables incoming and outgoing MQTT connections by apply firewall rules.
+     *
+     * @throws InterruptedException then thread has been interrupted
+     * @throws IOException on errors
+     */
     public abstract void disconnectMqtt() throws InterruptedException, IOException;
 
+    /**
+     * Enables incoming and outgoing MQTT connections.
+     *
+     * @throws InterruptedException then thread has been interrupted
+     * @throws IOException on errors
+     */
     public abstract void recoverMqtt() throws InterruptedException, IOException;
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
@@ -41,6 +41,10 @@ public class LinuxNetworkUtils extends NetworkUtils {
         this.commands = new LinuxCommands(device, pillboxContext);
     }
 
+    /**
+     * Disables incoming and outgoing MQTT connections.
+     * On Linux connections to/from 127.0.0.1 will still be allowed.
+     */
     @Override
     public void disconnectMqtt() throws InterruptedException, IOException {
         modifyMqttConnection(APPEND_OPTION);


### PR DESCRIPTION
**Issue #, if available:**
None. Has request to remove port 443 from post of blocked port of NetworkUtils.disconnectMqtt()

**Description of changes:**
- Remove port 443 from the list of ports to block
- Add javadoc to describe what is doing here

**Why is this change necessary:**
I do not know for sure

**How was this change tested:**
Not tested due to first should delivery changes to maven repo

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
