### PR TITLE
fix: add rollback of changes in list of IP addresses assigned to lo interface

### DIFF
--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/linux/LinuxNetworkUtils.java
@@ -26,9 +26,9 @@ public class LinuxNetworkUtils extends NetworkUtils {
     private static final String IPTABLES = "iptables";
     private static final String IP = "ip";
     private static final String[] TEMPLATES = {
-        "INPUT -p tcp -s 127.0.0.1 --dport %s -j ACCEPT",
+        "INPUT -p tcp -s localhost --dport %s -j ACCEPT",
         "INPUT -p tcp --dport %s -j DROP",
-        "OUTPUT -p tcp -d 127.0.0.1 --dport %s -j ACCEPT",
+        "OUTPUT -p tcp -d localhost --dport %s -j ACCEPT",
         "OUTPUT -p tcp --dport %s -j DROP"
     };
 


### PR DESCRIPTION
**Issue #, if available:**
OTF Step to add IP address to lo interface is not automatically reverted

**Description of changes:**
- Add rollback of changes in list of IP addresses assigned to lo interface
- Replace 127.0.0.1 to localhost in iptables rules

**Why is this change necessary:**
When step "I remove IP address" is missed in scenario or when skipped due to failure in some other step assigned IP addresses kept for lo interface. That can cause other scenarios to fail.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
