### PR TITLE
fix(docker): do not fail docker image cleanup

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-docker/src/main/java/com/aws/greengrass/testing/features/DockerSteps.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.testing.features;
 
+import com.aws.greengrass.testing.api.device.exception.CommandExecutionException;
 import com.aws.greengrass.testing.api.device.model.CommandInput;
 import com.aws.greengrass.testing.platform.Platform;
 import io.cucumber.guice.ScenarioScoped;
@@ -81,8 +82,17 @@ public class DockerSteps {
         }
     }
 
+    /**
+     * Cleanup after executing steps.
+     */
     @After
     public void removeCreatedImages() {
-        createdImages.forEach(this::removeDockerImage);
+        for (String createdImage : createdImages) {
+            try {
+                removeDockerImage(createdImage);
+            } catch (CommandExecutionException e) {
+                LOGGER.debug("Could not remove docker image {}", createdImage, e);
+            }
+        }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Docker image cleanup will fail if the image doesn't exist. Catch the exception, log it and then keep going. This should not cause any tests to fail.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
