### PR TITLE
feat: use CURRENT keyword as version of already deployed component

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -347,7 +347,7 @@ public class DeploymentSteps {
                 if (componentVersion == null) {
                     throw new IllegalStateException("Couldn't get version of component " + componentName);
                 }
-                LOGGER.info("Assume component {} has current version {}", componentName, componentVersion);
+                LOGGER.debug("Assume component {} has current version {}", componentName, componentVersion);
                 builder.componentVersion(componentVersion);
             } else {
                 componentPreparation.prepare(overrideNameVersion.build()).ifPresent(nameVersion -> {

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/DeploymentSteps.java
@@ -60,6 +60,7 @@ import static com.aws.greengrass.testing.features.GreengrassCliSteps.LOCAL_DEPLO
 @ScenarioScoped
 public class DeploymentSteps {
     private static final Logger LOGGER = LogManager.getLogger(DeploymentSteps.class);
+    private static final String CURRENT = "CURRENT";
     private static final String IOT_JOB_EXECUTION_STATUS_SUCCEEDED = "SUCCEEDED";
     private static final String LOCAL_STORE_RECIPES = "local:/local-store/recipes/";
     private final AWSResources resources;
@@ -177,9 +178,8 @@ public class DeploymentSteps {
         final String componentVersion = getComponentVersion(componentName);
         if (componentVersion == null) {
             throw new IllegalStateException("Couldn't get version of component " + componentName);
-        } else {
-            LOGGER.info("Updating configuration of component {}:{}", componentName, componentVersion);
         }
+        LOGGER.info("Updating configuration of component {}:{}", componentName, componentVersion);
         CommandInput command = getCliDeploymentCommand(componentName, componentVersion, configurations);
         createLocalDeploymentWithConfigs(0, command);
     }
@@ -340,10 +340,23 @@ public class DeploymentSteps {
             }
             overrides.component(name).ifPresent(overrideNameVersion::from);
             ComponentDeploymentSpecification.Builder builder = ComponentDeploymentSpecification.builder();
-            componentPreparation.prepare(overrideNameVersion.build()).ifPresent(nameVersion -> {
-                builder.componentVersion(nameVersion.version().value());
-            });
+
+            if (CURRENT.equals(value)) {
+                final String componentName = overrideNameVersion.build().name();
+                String componentVersion = getComponentVersionFromBackendDeployment(componentName);
+                if (componentVersion == null) {
+                    throw new IllegalStateException("Couldn't get version of component " + componentName);
+                }
+                LOGGER.info("Assume component {} has current version {}", componentName, componentVersion);
+                builder.componentVersion(componentVersion);
+            } else {
+                componentPreparation.prepare(overrideNameVersion.build()).ifPresent(nameVersion -> {
+                    builder.componentVersion(nameVersion.version().value());
+                });
+            }
+
             components.put(name, builder.build());
+
         });
         return components;
     }

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -40,7 +40,7 @@ Feature: Testing Cloud component in Greengrass
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorldMultiplatform log on the device contains the line "Hello World!" within 20 seconds
 
-  @CloudDeployment @IDT @OTFStable
+  @OTFStable
   Scenario: As a developer, I can create use CURRENT keyword as version of the component
     When I create a Greengrass deployment with components
       | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -39,3 +39,16 @@ Feature: Testing Cloud component in Greengrass
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorldMultiplatform log on the device contains the line "Hello World!" within 20 seconds
+
+  @CloudDeployment @IDT @OTFStable
+  Scenario: As a developer, I can create use CURRENT keyword as version of the component
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | classpath:/greengrass/components/recipes/hello_world_recipe.yaml |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    And the com.aws.HelloWorld log on the device contains the line "Hello World!!" within 20 seconds
+    # Deployment with the same version
+    When I create a Greengrass deployment with components
+      | com.aws.HelloWorld | CURRENT |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds


### PR DESCRIPTION
**Issue #, if available:**
#207 

**Description of changes:**
- Add CURRENT keyword as version of component to resolve #207 
- Add scenario to test new feature

**Why is this change necessary:**
Without that change we have an issue when do secondary deployment with the same classpath or localstore component

**How was this change tested:**
Automatically on CI by run new scenario

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
