### PR TITLE
chore: update aws sdk dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <cucumber.version>5.7.0</cucumber.version>
         <immutables.version>2.8.2</immutables.version>
         <log4j.version>2.17.1</log4j.version>
-        <aws.sdk.version>2.17.254</aws.sdk.version>
+        <aws.sdk.version>2.20.157</aws.sdk.version>
         <auto.service.version>1.0</auto.service.version>
         <findbugs.version>3.0.2</findbugs.version>
         <guice.version>5.0.1</guice.version>
@@ -147,6 +147,35 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.16.1</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>aws.sdk.version</name>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>software.amazon.awssdk</groupId>
+                                    <artifactId>bom</artifactId>
+                                    <version>latest</version>
+                                </dependency>
+                            </dependencies>
+                        </property>
+                    </properties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Bump the AWS SDK version to latest. 
- Use [`versions-maven-plugin`](https://www.mojohaus.org/versions/versions-maven-plugin/update-properties-mojo.html) to identify and update the aws java sdk version to latest in the pom.xml file using `update-properties` goal. 
- This plugin automatically updates the sdk version in the pom.xml when the project is built locally (using `mvn install`). Developers have to still commit the changes. 
- If the SDK version in the pom.xml is not the latest one available, the GitHub workflow fails (as it tries to update the pom.xml but fails as it doesn't have the permissions to update the file). If there's no update, the build step completes successfully. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
