### PR TITLE
feat: add step and platform commands for device network

### DIFF
--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/NetworkUtils.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 public abstract class NetworkUtils {
     protected static final String[] MQTT_PORTS = {"8883"};
+    protected static final String[] NETWORK_PORTS = {"443"};
 
     /**
      * Disables incoming and outgoing MQTT connections by apply firewall rules.
@@ -29,4 +30,8 @@ public abstract class NetworkUtils {
     public abstract void addLoopbackAddress(String address) throws IOException, InterruptedException;
 
     public abstract void deleteLoopbackAddress(String address) throws IOException, InterruptedException;
+
+    public abstract void disconnectNetwork() throws InterruptedException, IOException;
+
+    public abstract void recoverNetwork() throws InterruptedException, IOException;
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosNetworkUtils.java
@@ -5,11 +5,34 @@
 
 package com.aws.greengrass.testing.platform.macos;
 
+import com.aws.greengrass.testing.api.device.Device;
+import com.aws.greengrass.testing.api.device.model.CommandInput;
+import com.aws.greengrass.testing.api.model.PillboxContext;
 import com.aws.greengrass.testing.platform.NetworkUtils;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class MacosNetworkUtils extends NetworkUtils {
+    private static final org.apache.logging.log4j.Logger LOGGER = LogManager.getLogger(MacosNetworkUtils.class);
+    private static final String NETWORK_SETUP_COMMAND = "networksetup";
+    private static final String DOWN_OPERATION = "off";
+    private static final String UP_OPERATION = "on";
+    private static final String ACTIVE_SERVICE = "Active";
+    private static final String INACTIVE_SERVICE = "Inactive";
+    private static final long TIMEOUT_IN_SECONDS = 2L;
+    private static final AtomicBoolean networkDown = new AtomicBoolean(false);
+    private final MacosCommands commands;
+
+    MacosNetworkUtils(final Device device, final PillboxContext pillboxContext) {
+        this.commands = new MacosCommands(device, pillboxContext);
+    }
+
     @Override
     public void disconnectMqtt() throws InterruptedException, IOException {
         throw new UnsupportedOperationException("Operation not supported");
@@ -28,5 +51,62 @@ public class MacosNetworkUtils extends NetworkUtils {
     @Override
     public void deleteLoopbackAddress(String address) {
         throw new UnsupportedOperationException("Operation not supported");
+    }
+
+    @Override
+    public void disconnectNetwork() {
+        List<String> activeNetworkServices = networkServicesList().get(ACTIVE_SERVICE);
+        LOGGER.debug("Active network service {}", activeNetworkServices);
+        if (!activeNetworkServices.isEmpty()) {
+            for (String networkService : activeNetworkServices) {
+                commands.execute(CommandInput.builder()
+                        .line(NETWORK_SETUP_COMMAND)
+                        .addArgs("-setnetworkserviceenabled", networkService, DOWN_OPERATION)
+                        .timeout(TIMEOUT_IN_SECONDS)
+                        .build());
+            }
+            networkDown.set(true);
+        }
+    }
+
+    @Override
+    public void recoverNetwork() {
+        if (networkDown.get()) {
+            List<String> inactiveNetworkServices = networkServicesList().get(INACTIVE_SERVICE);
+            LOGGER.debug("Inactive network service {}", inactiveNetworkServices);
+            if (!inactiveNetworkServices.isEmpty()) {
+                for (String networkService : inactiveNetworkServices) {
+                    commands.execute(CommandInput.builder()
+                            .line(NETWORK_SETUP_COMMAND)
+                            .addArgs("-setnetworkserviceenabled", networkService, UP_OPERATION)
+                            .timeout(TIMEOUT_IN_SECONDS)
+                            .build());
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets list of all network services and creates a map with Active and Inactive status.
+     * @return Map of list of active and inactive network services
+     */
+    private Map<String, List<String>> networkServicesList() {
+        Map<String, List<String>> networkList = new HashMap<>();
+        String response = commands.executeToString(CommandInput.builder()
+                .line(NETWORK_SETUP_COMMAND)
+                .addArgs("-listallnetworkservices")
+                .build());
+        String[] networkServiceList = response.split("\\r?\\n|\\r");
+        for (int i = 1; i < networkServiceList.length; i++) {
+            String netService = networkServiceList[i];
+            if (netService.startsWith("*")) {
+                netService = "\"".concat(netService.substring(1, netService.length())).concat("\"");
+                networkList.computeIfAbsent(INACTIVE_SERVICE, k -> new ArrayList<>()).add(netService);
+            } else {
+                netService = "\"".concat(netService).concat("\"");
+                networkList.computeIfAbsent(ACTIVE_SERVICE, k -> new ArrayList<>()).add(netService);
+            }
+        }
+        return networkList;
     }
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/macos/MacosPlatform.java
@@ -23,6 +23,6 @@ public class MacosPlatform extends AbstractPlatform {
 
     @Override
     public NetworkUtils networkUtils() {
-        return new MacosNetworkUtils();
+        return new MacosNetworkUtils(device, pillboxContext);
     }
 }

--- a/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsNetworkUtils.java
+++ b/aws-greengrass-testing-platform/aws-greengrass-testing-platform-api/src/main/java/com/aws/greengrass/testing/platform/windows/WindowsNetworkUtils.java
@@ -103,7 +103,7 @@ public class WindowsNetworkUtils extends NetworkUtils {
         }
     }
 
-    private void runNetshCommand(String command, boolean ignoreError) throws IOException, InterruptedException {
+    private void runNetshCommand(String command, boolean ignoreError) {
         LOGGER.info("Running {} command: {}", NETSH, command);
 
         CommandInput commandInput = CommandInput.builder()
@@ -121,5 +121,15 @@ public class WindowsNetworkUtils extends NetworkUtils {
                 throw new RuntimeException(errorString, e);
             }
         }
+    }
+
+    @Override
+    public void disconnectNetwork() {
+        throw new UnsupportedOperationException("Operation not supported");
+    }
+
+    @Override
+    public void recoverNetwork() {
+        throw new UnsupportedOperationException("Operation not supported");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <cucumber.version>5.7.0</cucumber.version>
         <immutables.version>2.8.2</immutables.version>
         <log4j.version>2.17.1</log4j.version>
-        <aws.sdk.version>2.20.157</aws.sdk.version>
+        <aws.sdk.version>2.21.6</aws.sdk.version>
         <auto.service.version>1.0</auto.service.version>
         <findbugs.version>3.0.2</findbugs.version>
         <guice.version>5.0.1</guice.version>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Steps to set device network to offline and online.
Platform specific (Linux and MacOS) commands to run these steps.

**Why is this change necessary:**
To support confidence tests introduced in component template repo
PR: https://github.com/aws-greengrass/aws-greengrass-component-templates/pull/40

**How was this change tested:**
Tested locally on MacOS and used EC2 instances for testing Linux changes.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
