### PR TITLE
fix: enforce jackson version dependency to exclude correct duplicate

### DIFF
--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-ggipc/pom.xml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-ggipc/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
             <version>${iotdevicesdk.version}</version>

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/pom.xml
@@ -93,6 +93,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
             <version>${iotdevicesdk.version}</version>

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-mqtt/pom.xml
@@ -162,6 +162,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk.iotdevicesdk</groupId>
             <artifactId>aws-iot-device-sdk</artifactId>
             <version>${iotdevicesdk.version}</version>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add jackson-core to the pom.xml for aws-greengrass-testing-examples-component. This is placed above the iotdevicesdk dependency which will otherwise create a dependency on jackson 2.12.0 which conflicts with the version of jackson we do want.

**Why is this change necessary:**
When running the existing tests, I would always get a NoSuchMethodError for aws-greengrass-testing-examples-component. This is due to iotdevicesdk jar taking on a transitive dependency on jackson 2.12.0, which in turn excludes the 2.15.2 version of jackson that the project is actually trying to use as there is a conflict. This results in the NoSuchMethodError as the wrong jackson version is being used.

**How was this change tested:**
The tests that were previously failing out-of-box are able to run and pass with this change.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
