### PR TITLE
chore: bump minor version number to 1.3.0-SNAPSHOT in relevant places

### DIFF
--- a/aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/recipe.yaml
+++ b/aws-greengrass-testing-components/aws-greengrass-testing-components-streammanager/recipe.yaml
@@ -15,7 +15,7 @@ ComponentDependencies:
     DependencyType: HARD
 Manifests:
   - Artifacts:
-      - URI: "file:target/aws-greengrass-testing-components-streammanager-1.2.0-SNAPSHOT.jar"
+      - URI: "file:target/aws-greengrass-testing-components-streammanager-1.3.0-SNAPSHOT.jar"
     Lifecycle:
       Run: |
-        java -jar -Ds3.bucketName={configuration:/bucketName} -Ds3.key={configuration:/key} -Dfile.input={configuration:/inputFile} {artifacts:path}/aws-greengrass-testing-components-streammanager-1.2.0-SNAPSHOT.jar
+        java -jar -Ds3.bucketName={configuration:/bucketName} -Ds3.key={configuration:/key} -Dfile.input={configuration:/inputFile} {artifacts:path}/aws-greengrass-testing-components-streammanager-1.3.0-SNAPSHOT.jar

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/README.md
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/README.md
@@ -11,7 +11,7 @@ recipe template. The only difference being the URI portion:
 ``` yaml
 Manifests:
   - Artifacts:
-      - URI: "file:target/aws-greengrass-testing-examples-component-1.2.0-SNAPSHOT.jar"
+      - URI: "file:target/aws-greengrass-testing-examples-component-1.3.0-SNAPSHOT.jar"
 ```
 
 ### Integration Test Definition

--- a/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/recipe.yaml
+++ b/aws-greengrass-testing-examples/aws-greengrass-testing-examples-component/recipe.yaml
@@ -18,7 +18,7 @@ ComponentConfiguration:
             - "say/ping"
 Manifests:
   - Artifacts:
-      - URI: "file:target/aws-greengrass-testing-examples-component-1.2.0-SNAPSHOT.jar"
+      - URI: "file:target/aws-greengrass-testing-examples-component-1.3.0-SNAPSHOT.jar"
     Lifecycle:
       Run: |
-        java -jar {artifacts:path}/aws-greengrass-testing-examples-component-1.2.0-SNAPSHOT.jar
+        java -jar {artifacts:path}/aws-greengrass-testing-examples-component-1.3.0-SNAPSHOT.jar

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-api/src/main/java/com/aws/greengrass/testing/features/LoggerSteps.java
@@ -65,7 +65,7 @@ public class LoggerSteps {
 
     private String getOTFVersionLogContent() {
         final String otfVersion = Optional.ofNullable(LoggerSteps.class.getPackage().getImplementationVersion())
-                .orElse("1.2.0-SNAPSHOT");
+                .orElse("1.3.0-SNAPSHOT");
         return String.format("%s-%s", OTF_VERSION_PREFIX, otfVersion);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </modules>
 
     <properties>
-        <revision>1.2.0-SNAPSHOT</revision>
+        <revision>1.3.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump versions to 1.3.0-SNAPSHOT in all relevant places.

**Why is this change necessary:**
1.2.0 is released, so we want the current main branch to track 1.3.0-SNAPSHOT.

**How was this change tested:**
N/A

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
