### PR TITLE
chore: use sh in multiplatform recipes for better compatibility

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml
@@ -23,10 +23,10 @@ Manifests:
 - Platform:
     os: linux
   Artifacts:
-    - URI: file:/bin/bash
+    - URI: file:/bin/sh
       Permission:
         Read: ALL
         Execute: ALL
   Lifecycle:
     run: |
-      bash -c "echo -ne \"Hello World!\n\""
+      sh -c "echo -ne \"Hello World!\n\""

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world_multiplatform.yaml
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/components/recipes/local_hello_world_multiplatform.yaml
@@ -23,10 +23,10 @@ Manifests:
 - Platform:
     os: linux
   Artifacts:
-    - URI: file:/bin/bash
+    - URI: file:/bin/sh
       Permission:
         Read: ALL
         Execute: ALL
   Lifecycle:
     run: |
-      bash -c "echo -ne \"Hello World!\n\""
+      sh -c "echo -ne \"Hello World!\n\""


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Replace usage of `bash` with `sh`, should increase compatibility as some devices may not have bash installed

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
