### PR TITLE
chore: remove IDT tag from multiplatform component feature tests

### DIFF
--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-cloudcomponent/src/main/resources/greengrass/features/cloudComponent.feature
@@ -32,7 +32,7 @@ Feature: Testing Cloud component in Greengrass
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     And the com.aws.HelloWorld log on the device contains the line "Hello World Updated!!" within 20 seconds
 
-  @CloudDeployment @IDT @OTFStable
+  @CloudDeployment @OTFStable
   Scenario: As a developer, I can create a multi-platform component in Cloud and deploy it on my device
     When I create a Greengrass deployment with components
       | com.aws.HelloWorldMultiplatform | classpath:/greengrass/components/recipes/hello_world_recipe_multiplatform.yaml |

--- a/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
+++ b/aws-greengrass-testing-features/aws-greengrass-testing-features-localdeployment/src/main/resources/greengrass/features/localdeployment.feature
@@ -16,7 +16,7 @@ Feature: Testing local deployment using CLI in Greengrass
     Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
     And the aws.greengrass.LocalHelloWorld log on the device contains the line "Hello World!!" within 20 seconds
 
-  @LocalDeployment @IDT @OTFStable
+  @LocalDeployment @OTFStable
   Scenario: A multi-platform component is deployed locally using CLI
     When I create a Greengrass deployment with components
       | aws.greengrass.Cli | GG_CLI_VERSION |


### PR DESCRIPTION
**Issue #, if available:**
P123929293

**Description of changes:**
Disable multi-platform component feature tests when running in IDT

**Why is this change necessary:**
These tests are not necessary for IDT

**How was this change tested:**
n/a

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
