### PR TITLE
Add the test_FleetStatus_1_T3

### DIFF
--- a/components/BrokenAfterDeployed/1.0.0/artifacts/broken_after_deployed.py
+++ b/components/BrokenAfterDeployed/1.0.0/artifacts/broken_after_deployed.py
@@ -1,0 +1,7 @@
+import sys
+import time
+
+sleep_time = int(sys.argv[1])
+time.sleep(sleep_time)
+
+raise NotImplementedError("Not implemented.")

--- a/components/BrokenAfterDeployed/1.0.0/recipe/BrokenAfterDeployed-1.0.0.yaml
+++ b/components/BrokenAfterDeployed/1.0.0/recipe/BrokenAfterDeployed-1.0.0.yaml
@@ -1,0 +1,28 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: _BrokenAfterDeployed_
+ComponentVersion: "1.0.0"
+ComponentConfiguration:
+  DefaultConfiguration:
+    SleepTime: 10 #TODO: Allow configurable value
+ComponentDescription:
+  Component that becomes broken after a successful deployment and raises
+  exception
+ComponentPublisher: Amazon
+Manifests:
+  - Platform:
+      os: windows
+    Artifacts:
+      - URI: s3://$bucketName$/$testArtifactsDirectory$/broken_after_deployed.py
+    Lifecycle:
+      run:
+        python {artifacts:path}/broken_after_deployed.py
+        {configuration:/SleepTime}
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Artifacts:
+      - URI: s3://$bucketName$/$testArtifactsDirectory$/broken_after_deployed.py
+    Lifecycle:
+      run: |-
+        python3 {artifacts:path}/broken_after_deployed.py {configuration:/SleepTime};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,13 @@ dependencies = [
     "types-boto3[essential,greengrassv2,iot,iot-data]>=1.38.4",
 ]
 
-
 [tool.pytest.ini_options]
 testpaths = [
     "./src/*",
 ]
+
+[tool.yapf]
+based_on_style = "pep8"
+spaces_before_comment = 4
+split_before_logical_operator = true
+column_limit = 80

--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -365,7 +365,8 @@ class GGTestUtils:
             print(f"ggl.{service}.service")
         self._ggServiceList = []
 
-    def get_ggcore_device_status(self, timeout: int | float, thing_group_name: str) -> Optional[CoreDeviceStatusType]:
+    def wait_ggcore_device_status(self, timeout: int | float, thing_group_name,
+                                 desired_health: str) -> Optional[CoreDeviceStatusType]:
         things_in_group = self._iotClient.list_things_in_thing_group(
             thingGroupName=thing_group_name,
             recursive=False,
@@ -380,10 +381,10 @@ class GGTestUtils:
             return_val = self._ggClient.get_core_device(
                 coreDeviceThingName=things_in_group["things"][0])
 
-            if return_val is None or return_val["status"] != "HEALTHY":
+            if return_val is None or return_val["status"] != desired_health:
                 time.sleep(1)
                 timeout -= 1
             else:
-                return return_val["status"]
+                return True
 
-        return None
+        return False


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
```
(env) ubuntu@ip-172-31-87-177:~/repo/aws-greengrass-testing$ pytest -q -s -v  -k "test_FleetStatus_1_T3"
====================================================================================================================================== test session starts =======================================================================================================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/ubuntu/repo/aws-greengrass-testing
configfile: pyproject.toml
testpaths: ./src/*
collected 18 items / 17 deselected / 1 selected                                                                                                                                                                                                                                                  

src/aws-greengrass-testing-fleet-status.py File /home/ubuntu/repo/aws-greengrass-testing/components/BrokenAfterDeployed/1.0.0/artifacts/broken_after_deployed.py successfully uploaded to gglite-dev-test-us-east-1/artifacts/broken_after_deployed.py
Successfully uploaded component with ARN: arn:aws:greengrass:us-east-1:891377305071:components:_BrokenAfterDeployed_e9fbced3-255e-11f0-a884-126259ffcd49:versions:1.0.0
.ggl._BrokenAfterDeployed_e9fbced3-255e-11f0-a884-126259ffcd49.service


============================================================================================================================= warnings summary ==============================================================================================================================
src/aws-greengrass-testing-fleet-status.py::test_FleetStatus_1_T3
  /home/ubuntu/repo/aws-greengrass-testing/env/lib/python3.12/site-packages/botocore/utils.py:670: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    current_time = datetime.datetime.utcnow()

src/aws-greengrass-testing-fleet-status.py: 104 warnings
  /home/ubuntu/repo/aws-greengrass-testing/env/lib/python3.12/site-packages/botocore/auth.py:425: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================= 1 passed, 17 deselected, 105 warnings in 78.42s (0:01:18) =========================================================================================================
```
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
