### PR TITLE
Extend cloud create deployment enabling merge config values

### DIFF
--- a/.github/scripts/binaryCompatibility.py
+++ b/.github/scripts/binaryCompatibility.py
@@ -61,8 +61,7 @@ def main():
         "GITHUB_REPOSITORY")].issues[pr].comments.get()
     if existing_comments[0] == 200:
         existing_comments = list(
-            filter(lambda i: my_body_dedupe in i["body"],
-                   existing_comments[1]))
+            filter(lambda i: my_body_dedupe in i["body"], existing_comments[1]))
     else:
         existing_comments = []
 

--- a/.github/scripts/cover2cover.py
+++ b/.github/scripts/cover2cover.py
@@ -51,7 +51,7 @@ def convert_lines(j_lines, into):
         cline.set('number', jline.attrib['nr'])
         cline.set(
             'hits', '1' if ci > 0 else
-            '0')  # Probably not true but no way to know from JaCoCo XML file
+            '0')    # Probably not true but no way to know from JaCoCo XML file
 
         if mb + cb > 0:
             percentage = str(int(100 * (float(cb) /

--- a/config/config.py
+++ b/config/config.py
@@ -5,7 +5,7 @@ aws_account = ""
 s3_bucket_name = ""
 
 # The region of the AWS Account used for the tests.
-region = ""
+region = "us-east-1"
 
 # First thing group with 'thing' under test added to it.
 thing_group_1 = ""

--- a/config/config.py
+++ b/config/config.py
@@ -5,7 +5,7 @@ aws_account = ""
 s3_bucket_name = ""
 
 # The region of the AWS Account used for the tests.
-region = "us-east-1"
+region = ""
 
 # First thing group with 'thing' under test added to it.
 thing_group_1 = ""

--- a/src/SystemInterface.py
+++ b/src/SystemInterface.py
@@ -52,7 +52,7 @@ class SystemInterface:
                 "journalctl",
                 "-xeau",
                 service_name,
-                "-f",  # Follow mode - shows new entries as they are added
+                "-f",    # Follow mode - shows new entries as they are added
             ]
 
             # Run the command and stream output

--- a/src/aws-greengrass-testing-component.py
+++ b/src/aws-greengrass-testing-component.py
@@ -5,7 +5,7 @@ from src.SystemInterface import SystemInterface
 from config import config
 
 
-@pytest.fixture(scope="function")  # Runs for each test function
+@pytest.fixture(scope="function")    # Runs for each test function
 def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
@@ -21,7 +21,7 @@ def gg_util_obj():
     gg_util.cleanup()
 
 
-@pytest.fixture(scope="function")  # Runs for each test function
+@pytest.fixture(scope="function")    # Runs for each test function
 def system_interface():
     interface = SystemInterface()
 

--- a/src/aws-greengrass-testing-deployment.py
+++ b/src/aws-greengrass-testing-deployment.py
@@ -6,7 +6,7 @@ from src.SystemInterface import SystemInterface
 from config import config
 
 
-@pytest.fixture(scope="function")  # Runs for each test function
+@pytest.fixture(scope="function")    # Runs for each test function
 def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
@@ -22,7 +22,7 @@ def gg_util_obj():
     gg_util.cleanup()
 
 
-@pytest.fixture(scope="function")  # Runs for each test function
+@pytest.fixture(scope="function")    # Runs for each test function
 def system_interface():
     interface = SystemInterface()
 
@@ -33,7 +33,7 @@ def system_interface():
     pass
 
 
-@pytest.fixture(scope="function")  # Runs for each test function
+@pytest.fixture(scope="function")    # Runs for each test function
 def iot_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.

--- a/src/aws-greengrass-testing-fleet-status.py
+++ b/src/aws-greengrass-testing-fleet-status.py
@@ -86,5 +86,5 @@ def test_FleetStatus_1_T3(gg_util_obj):
     #    And I can get the thing status as "UNHEALTHY" with all uploaded components within 180 seconds with groups
     #        | FssThingGroup |
     assert (gg_util_obj.wait_ggcore_device_status(180, config.thing_group_1,
-                                                 "UNHEALTHY")
+                                                  "UNHEALTHY")
             )    #TODO: create and use FssThingGroup instead of thing_group_1

--- a/src/aws-greengrass-testing-fleet-status.py
+++ b/src/aws-greengrass-testing-fleet-status.py
@@ -57,7 +57,7 @@ def test_FleetStatus_1_T1(gg_util_obj: GGTestUtils):
 
     # And I can get the thing status as "HEALTHY" with all uploaded components within 60 seconds with groups
     #      | FssThingGroup |
-    assert (gg_util_obj.wait_ggcore_device_status(
+    assert (gg_util_obj.get_ggcore_device_status(
         60, f"{gg_util_obj.get_thing_group()}", "HEALTHY"))
 
 
@@ -85,6 +85,6 @@ def test_FleetStatus_1_T3(gg_util_obj):
 
     #    And I can get the thing status as "UNHEALTHY" with all uploaded components within 180 seconds with groups
     #        | FssThingGroup |
-    assert (gg_util_obj.wait_ggcore_device_status(180, config.thing_group_1,
+    assert (gg_util_obj.get_ggcore_device_status(180, config.thing_group_1,
                                                  "UNHEALTHY")
             )    #TODO: create and use FssThingGroup instead of thing_group_1

--- a/src/aws-greengrass-testing-fleet-status.py
+++ b/src/aws-greengrass-testing-fleet-status.py
@@ -57,7 +57,7 @@ def test_FleetStatus_1_T1(gg_util_obj: GGTestUtils):
 
     # And I can get the thing status as "HEALTHY" with all uploaded components within 60 seconds with groups
     #      | FssThingGroup |
-    assert (gg_util_obj.get_ggcore_device_status(
+    assert (gg_util_obj.wait_ggcore_device_status(
         60, f"{gg_util_obj.get_thing_group()}", "HEALTHY"))
 
 
@@ -85,6 +85,6 @@ def test_FleetStatus_1_T3(gg_util_obj):
 
     #    And I can get the thing status as "UNHEALTHY" with all uploaded components within 180 seconds with groups
     #        | FssThingGroup |
-    assert (gg_util_obj.get_ggcore_device_status(180, config.thing_group_1,
+    assert (gg_util_obj.wait_ggcore_device_status(180, config.thing_group_1,
                                                  "UNHEALTHY")
             )    #TODO: create and use FssThingGroup instead of thing_group_1

--- a/src/aws-greengrass-testing-security.py
+++ b/src/aws-greengrass-testing-security.py
@@ -31,6 +31,7 @@ def system_interface():
     pass
 
 
+#TODO: INCOMPLETE only partially implemented
 # Scenario Outline: Security-6-T2-mqtt: As a service owner, I want to specify which components can publish on which mqtt topic
 def test_Security_6_T2_mqtt(gg_util_obj, system_interface):
     #   When I install the component IotMqttPublisher version 0.0.0 from local store with configuration

--- a/src/aws-greengrass-testing-security.py
+++ b/src/aws-greengrass-testing-security.py
@@ -1,0 +1,69 @@
+import time
+import pytest
+from src.GGTestUtils import GGTestUtils
+from src.SystemInterface import SystemInterface
+from config import config
+
+
+@pytest.fixture(scope="function")    # Runs for each test function
+def gg_util_obj():
+    # Setup an instance of the GGUtils class. It is then passed to the
+    # test functions.
+    gg_util = GGTestUtils(config.aws_account, config.s3_bucket_name,
+                          config.region, config.ggl_cli_bin_path)
+
+    # yield the instance of the class to the tests.
+    yield gg_util
+
+    # This section is called AFTER the test is run.
+
+    # Cleanup the artifacts, components etc.
+    gg_util.cleanup()
+
+
+@pytest.fixture(scope="function")    # Runs for each test function
+def system_interface():
+    interface = SystemInterface()
+
+    # yield the instance of the class to the tests.
+    yield interface
+
+    # This section is called AFTER the test is run.
+    pass
+
+
+# Scenario Outline: Security-6-T2-mqtt: As a service owner, I want to specify which components can publish on which mqtt topic
+def test_Security_6_T2_mqtt(gg_util_obj, system_interface):
+    #   When I install the component IotMqttPublisher version 0.0.0 from local store with configuration
+    #     | value                                                                                                                                                                                                                                                        |
+    #     | {"MERGE":{"accessControl":{"aws.greengrass.ipc.mqttproxy":{"policyId1":{"policyDescription":"access to publish to mqtt topics","operations":["aws.greengrass#PublishToIoTCore"],"resources":["<resource>"]}}},"topic":"<topic>","QOS":"1","payload":"test"}} |
+    IotMqttPublisher_cloud_name = gg_util_obj.upload_component_with_version(
+        "IotMqttPublisher", "0.0.0")
+    if IotMqttPublisher_cloud_name is None:
+        raise RuntimeError(
+            "Fatal error: IotMqttPublisher_cloud_name cannot be uploaded to cloud"
+        )
+
+    #TODO: MOdify this to use the python pubsub assertion component.
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(config.thing_group_1), [
+            IotMqttPublisher_cloud_name +
+            ("{\"accessControl\":{\"aws.greengrass.ipc.mqttproxy\":{\"policyId1\":{\"policyDescription\":\"access to publish to mqtt topics\",\"operations\":[\"aws.greengrass#PublishToIoTCore\"],\"resources\":[\"<resource>\"]}}},\"topic\":\"<topic>\",\"QOS\":\"1\",\"payload\":\"test\"}",
+             )
+        ], "FirstDeployment")["deploymentId"]
+
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "SUCCEEDED")
+
+    #   Then I can check the cli to see the status of component IotMqttPublisher is RUNNING
+    assert system_interface.check_systemctl_status_for_component(
+        IotMqttPublisher_cloud_name[0]) == "RUNNING"
+
+
+#   And I get 1 assertion with context "Successfully published to IoT topic <topic>"
+#   Examples:
+#     | resource                             | topic                                              |
+#     | test/topic                           | test/topic                                         |
+#     | testStarWildcard/topic*suffix/match* | testStarWildcard/topic-A/B/C-suffix/match-star/1/2 |
+#     | topic*suffix/+/level/#               | topic-A/B-suffix/matchPlus/level/match/pound       |
+#     | test\${?}escape\${$}char*            | test?escape$char1/2/3                              |

--- a/src/aws-greengrass-testing-security.py
+++ b/src/aws-greengrass-testing-security.py
@@ -1,11 +1,10 @@
-import time
-import pytest
+from pytest import fixture
 from src.GGTestUtils import GGTestUtils
 from src.SystemInterface import SystemInterface
 from config import config
 
 
-@pytest.fixture(scope="function")    # Runs for each test function
+@fixture(scope="function")    # Runs for each test function
 def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
@@ -21,7 +20,7 @@ def gg_util_obj():
     gg_util.cleanup()
 
 
-@pytest.fixture(scope="function")    # Runs for each test function
+@fixture(scope="function")    # Runs for each test function
 def system_interface():
     interface = SystemInterface()
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- This PR will extend cloud create deployment enabling merge config values for generic components
- Format files as per the formatting guidelines
- Adds a partially complete security test

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
