### PR TITLE
Add new component and deployment tests

### DIFF
--- a/components/HelloWorldBroken/1.0.0/recipe/HelloWorldBroken-1.0.0.yaml
+++ b/components/HelloWorldBroken/1.0.0/recipe/HelloWorldBroken-1.0.0.yaml
@@ -1,0 +1,23 @@
+---
+RecipeFormatVersion: "2020-01-25"
+componentName: HelloWorldBroken
+ComponentVersion: "1.0.0"
+ComponentConfiguration:
+  DefaultConfiguration:
+    Message: "World"
+ComponentDescription: Hello World App
+ComponentPublisher: Amazon
+manifests:
+  - Platform:
+      os: windows
+    lifecycle:
+      startup: |-
+        powershell -command "& { echo \"Broken Hello {configuration:/Message}\"; exit 1 }"
+
+  - Platform:
+      os: "*"
+      runtime: "*"
+    lifecycle:
+      startup: |-
+        echo 'Broken Hello {configuration:/Message}'
+        exit 1

--- a/components/Minimal/1.0.0/recipe/Minimal-1.0.0.yaml
+++ b/components/Minimal/1.0.0/recipe/Minimal-1.0.0.yaml
@@ -1,0 +1,27 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: Minimal
+ComponentVersion: "1.0.0"
+ComponentDescription: A minimal component
+ComponentPublisher: Amazon
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      run: >-
+        powershell -command while(1) {
+        echo 'Minimal-1.0.0 ran';
+        sleep 5 }
+      shutdown: >-
+        echo Goodbye from Minimal-1.0.0
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        while true; do
+        echo Minimal-1.0.0 ran
+        sleep 5
+        done
+      shutdown: |-
+        echo Goodbye from Minimal-1.0.0

--- a/components/Minimal/2.0.0/recipe/Minimal-2.0.0.yaml
+++ b/components/Minimal/2.0.0/recipe/Minimal-2.0.0.yaml
@@ -1,0 +1,20 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: Minimal
+ComponentVersion: "2.0.0"
+ComponentDescription: A minimal component
+ComponentPublisher: Amazon
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      run: >-
+        powershell -command "& { while(1) { echo \"Minimal-2.0.0 ran\"; sleep 5 } }"
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        while true; do
+        echo Minimal-2.0.0 ran; sleep 5
+        done

--- a/components/Minimal/3.0.0/recipe/Minimal-3.0.0.yaml
+++ b/components/Minimal/3.0.0/recipe/Minimal-3.0.0.yaml
@@ -1,0 +1,20 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: Minimal
+ComponentVersion: "3.0.0"
+ComponentDescription: A minimal component
+ComponentPublisher: Amazon
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      run: >-
+        powershell -command "& { while(1) { echo \"Minimal-3.0.0 ran\"; sleep 5 } }"
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        while true; do
+        echo Minimal-3.0.0 ran; sleep 5
+        done

--- a/components/Minimal/4.0.0/recipe/Minimal-4.0.0.yaml
+++ b/components/Minimal/4.0.0/recipe/Minimal-4.0.0.yaml
@@ -1,0 +1,20 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: Minimal
+ComponentVersion: "4.0.0"
+ComponentDescription: A minimal component
+ComponentPublisher: Amazon
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      run: >-
+        powershell -command "& { while(1) { echo \"Minimal-4.0.0 ran\"; sleep 5 } }"
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        while true; do
+        echo Minimal-4.0.0 ran; sleep 5
+        done

--- a/components/SampleComponentWithArtifacts/1.0.0/artifacts/sample_artifact.py
+++ b/components/SampleComponentWithArtifacts/1.0.0/artifacts/sample_artifact.py
@@ -1,4 +1,0 @@
-message = "Hi from generic sample component artifact."
-
-# print to stdout
-print(message)

--- a/components/aws.gg.uat.cloud.ComponentConfigTestService/1.0.0/recipe/aws.gg.uat.cloud.ComponentConfigTestService-1.0.0.yaml
+++ b/components/aws.gg.uat.cloud.ComponentConfigTestService/1.0.0/recipe/aws.gg.uat.cloud.ComponentConfigTestService-1.0.0.yaml
@@ -1,0 +1,55 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: _aws.gg.uat.cloud.ComponentConfigTestService_
+ComponentDescription: This is dedicated for testing component configuration for cloud and local deployments.
+ComponentPublisher: Me
+ComponentVersion: "1.0.0"
+
+# Configuration section to test and assert
+# Texts below are used for assertion in Component-29 and need to be changed together.
+ComponentConfiguration:
+  DefaultConfiguration:
+    singleLevelKey: "default value of singleLevelKey"
+    nestedKey:
+      leafKey: "default value of /nestedKey/leafKey"
+    listKey:
+      - "item1"
+      - "item2"
+    emptyStringKey: ""
+    emptyListKey: []
+    emptyObjectKey: {}
+    defaultIsNullKey: null
+    willBeNullKey: "I will be set to null soon"
+
+Manifests:
+  - Platform:
+      os: "windows"
+    Lifecycle:
+      # Texts below are used for assertion in Component-29 and need to be changed together.
+      run:
+        Script: >-
+          powershell -command "& { echo $env:BypassCMD;
+          echo \"done\" }"
+        Setenv:
+          BypassCMD: >-
+            aws.iot.gg.uat.ComponentConfigTestService output
+            Value for /singleLevelKey: {configuration:/singleLevelKey}.
+            Value for /nestedKey/leafKey: {configuration:/nestedKey/leafKey}.
+            Value for /nestedKey: {configuration:/nestedKey}. I will be interpolated as a serialized JSON String.
+            Value for /listKey/0: {configuration:/listKey/0}.
+            Value for /emptyStringKey: {configuration:/emptyStringKey}.
+            Value for /defaultIsNullKey: {configuration:/defaultIsNullKey}.
+            Value for /newSingleLevelKey: {configuration:/newSingleLevelKey}. I was not in the default value.
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      # Texts below are used for assertion in Component-29 and need to be changed together.
+      run: >-
+        echo "aws.iot.gg.uat.ComponentConfigTestService output
+        Value for /singleLevelKey: {configuration:/singleLevelKey}.
+        Value for /nestedKey/leafKey: {configuration:/nestedKey/leafKey}.
+        Value for /nestedKey: {configuration:/nestedKey}. I will be interpolated as a serialized JSON String.
+        Value for /emptyStringKey: {configuration:/emptyStringKey}.
+        Value for /defaultIsNullKey: {configuration:/defaultIsNullKey}.
+        Value for /newSingleLevelKey: {configuration:/newSingleLevelKey}. I was not in the default value." && echo "done"

--- a/components/aws.gg.uat.local.ComponentConfigTestService/1.0.0/recipe/aws.gg.uat.local.ComponentConfigTestService-1.0.0.yaml
+++ b/components/aws.gg.uat.local.ComponentConfigTestService/1.0.0/recipe/aws.gg.uat.local.ComponentConfigTestService-1.0.0.yaml
@@ -1,0 +1,53 @@
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: aws.gg.uat.local.ComponentConfigTestService
+ComponentDescription: This is dedicated for testing component configuration with
+  local only deployments
+ComponentPublisher: Me
+ComponentVersion: 1.0.0
+ComponentConfiguration:
+  DefaultConfiguration:
+    singleLevelKey: default value of singleLevelKey
+    nestedKey:
+      leafKey: default value of /nestedKey/leafKey
+    listKey:
+      - item1
+      - item2
+    emptyStringKey: ""
+    emptyListKey: []
+    emptyObjectKey: {}
+    defaultIsNullKey: null
+    willBeNullKey: I will be set to null soon
+Manifests:
+  - Platform:
+      os: windows
+    Lifecycle:
+      run:
+        Script: powershell -command "& { echo $env:BypassCMD; python
+          {artifacts:path}/print_json_env.py; echo \"done\" }"
+        Setenv:
+          BypassCMD: "aws.iot.gg.uat.ComponentConfigTestService output Value for
+            /singleLevelKey: {configuration:/singleLevelKey}. Value for
+            /nestedKey/leafKey: {configuration:/nestedKey/leafKey}. Value for
+            /nestedKey: {configuration:/nestedKey}. I will be interpolated as a
+            serialized JSON String. Value for /emptyStringKey:
+            {configuration:/emptyStringKey}. Value for /defaultIsNullKey:
+            {configuration:/defaultIsNullKey}. Value for /newSingleLevelKey:
+            {configuration:/newSingleLevelKey}. I was not in the default value."
+          testJsonEnvvar: "{configuration:/nestedKey}"
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run:
+        Setenv:
+          testJsonEnvvar: "{configuration:/nestedKey}"
+        Script: >-
+          echo 'aws.iot.gg.uat.ComponentConfigTestService output
+          Value for /singleLevelKey: {configuration:/singleLevelKey}.
+          Value for /nestedKey/leafKey: {configuration:/nestedKey/leafKey}.
+          Value for /nestedKey: {configuration:/nestedKey}. I will be interpolated as a serialized JSON String.
+          Value for /emptyStringKey: {configuration:/emptyStringKey}.
+          Value for /defaultIsNullKey: {configuration:/defaultIsNullKey}.
+          Value for /newSingleLevelKey: {configuration:/newSingleLevelKey}. I was not in the default value.'
+          && python3 {artifacts:path}/print_json_env.py && echo "done"

--- a/components/local_artifacts/SampleComponentWithArtifacts/1.0.0/sample_artifact.py
+++ b/components/local_artifacts/SampleComponentWithArtifacts/1.0.0/sample_artifact.py
@@ -1,0 +1,4 @@
+message = "Hi from generic sample component artifact."
+
+# print to stdout
+print(message)

--- a/components/local_artifacts/aws.gg.uat.local.ComponentConfigTestService/1.0.0/print_json_env.py
+++ b/components/local_artifacts/aws.gg.uat.local.ComponentConfigTestService/1.0.0/print_json_env.py
@@ -1,0 +1,9 @@
+import os
+import json
+
+json_str = os.environ['testJsonEnvvar']
+json_obj = json.loads(json_str)
+if json_obj['leafKey'] == 'default value of /nestedKey/leafKey':
+    print('Verified JSON interpolation from script')
+else:
+    print('Failed to verify JSON envvar. Got:', json_str)

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,7 @@ s3_bucket_name = ""
 
 # The region of the AWS Account used for the tests.
 region = ""
-
+"
 # First thing group with 'thing' under test added to it.
 thing_group_1 = ""
 
@@ -18,3 +18,6 @@ thing_name = ""
 
 # Location of ggl-cli binary
 ggl_cli_bin_path = "../aws-greengrass-lite/build/bin/ggl-cli"
+
+# GGL install directory
+ggl_install_dir = "/var/lib/greengrass/"

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,7 @@ s3_bucket_name = ""
 
 # The region of the AWS Account used for the tests.
 region = ""
-"
+
 # First thing group with 'thing' under test added to it.
 thing_group_1 = ""
 

--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -13,6 +13,7 @@ from types_boto3_iot import IoTClient
 from types_boto3_s3 import S3Client
 import yaml
 from subprocess import run
+from pathlib import Path
 from typing import Sequence, Optional, Any, Dict, List, Literal, Optional, Sequence, NamedTuple
 
 S3_ARTIFACT_DIR = "artifacts"
@@ -39,11 +40,12 @@ class GGTestUtils:
     _ggDeploymentList: List[str]
 
     def __init__(self, account: str, bucket: str, region: str,
-                 cli_bin_path: str):
+                 cli_bin_path: str, install_dir: str):
         self._region = region
         self._account = account
         self._bucket = bucket
         self._cli_bin_path = cli_bin_path
+        self._install_dir = install_dir
         self._ggClient = boto3.client("greengrassv2", region_name=self._region)
         self._iotClient = boto3.client("iot", region_name=self._region)
         self._s3Client = boto3.client("s3", region_name=self._region)
@@ -67,6 +69,10 @@ class GGTestUtils:
     @property
     def cli_bin_path(self) -> str:
         return self._cli_bin_path
+
+    @property
+    def install_dir(self) -> str:
+        return self._install_dir
 
     def get_thing_group_arn(self, thing_group: str) -> str:
         return f"arn:aws:iot:{self.aws_region}:{self.aws_account}:thinggroup/{thing_group}"
@@ -487,3 +493,7 @@ class GGTestUtils:
         except Exception as e:
             print(f"Error uploading component: {e}")
             raise
+
+    def recipe_for_component_exists(self, component_name: str, component_version: str):
+        print(f"Checking if file {(Path(self._install_dir) / "packages/recipes" / f"{component_name}-{component_version}.yaml")} exists")
+        return (Path(self._install_dir) / "packages/recipes" / f"{component_name}-{component_version}.yaml").exists()

--- a/src/SystemInterface.py
+++ b/src/SystemInterface.py
@@ -7,7 +7,7 @@ from typing import Literal
 class SystemInterface:
 
     def check_systemctl_status_for_component(
-            self, component_name: str) -> Literal['RUNNING', 'NOT_RUNNING']:
+            self, component_name: str) -> Literal['RUNNING', 'FINISHED', 'NOT_RUNNING']:
         try:
             cmd = [
                 "sudo",
@@ -26,11 +26,15 @@ class SystemInterface:
 
             output, errors = process.communicate()
             if output:
-                if len(output.split("\n")) > 2:
-                    if "Active: active (running)" in output.split(
-                            "\n")[2].strip():
-                        print(f"Process is active")
+                if len(output.split("\n")) > 4:
+                    active_line = output.split("\n")[2].strip()
+                    process_line = output.split("\n")[4].strip()
+                    if "Active: active (running)" in active_line:
+                        print("Process is active")
                         return "RUNNING"
+                    elif ("Active: inactive (dead)" in active_line) and ("status=0/SUCCESS" in process_line):
+                        print("Process is finished")
+                        return "FINISHED"
 
             process.terminate()
 

--- a/src/aws-greengrass-testing-component.py
+++ b/src/aws-greengrass-testing-component.py
@@ -10,7 +10,8 @@ def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
     gg_util = GGTestUtils(config.aws_account, config.s3_bucket_name,
-                          config.region, config.ggl_cli_bin_path)
+                          config.region, config.ggl_cli_bin_path,
+                          config.ggl_install_dir)
 
     # yield the instance of the class to the tests.
     yield gg_util
@@ -131,3 +132,227 @@ def test_Component_27_T1(gg_util_obj, system_interface):
         "Failed to verify digest.",
         timeout=30,
     ) is True)
+
+# As an operator, I can interpolate component default configurations by local deployment.
+def test_Component_29_T0(gg_util_obj, system_interface):
+    # I install the component aws.gg.uat.local.ComponentConfigTestService version 1.0.0 from local store
+    component_artifacts_dir = "./components/local_artifacts/"
+    component_recipe_dir = "./components/aws.gg.uat.local.ComponentConfigTestService/1.0.0/recipe/"
+    assert (gg_util_obj.create_local_deployment(component_artifacts_dir, component_recipe_dir, "aws.gg.uat.local.ComponentConfigTestService=1.0.0"))
+    # TODO: We can use the CLI to verify that a local deployment has finished once that feature exists
+    # For now, check if the expected component is running within a timeout.
+    timeout = 120
+    while timeout > 0:
+        if system_interface.check_systemctl_status_for_component("aws.gg.uat.local.ComponentConfigTestService") == "FINISHED":
+            break
+        time.sleep(1)
+        timeout -= 1
+
+    # I can check the cli to see the status of component aws.gg.uat.local.ComponentConfigTestService is FINISHED
+    assert (system_interface.check_systemctl_status_for_component(
+        "aws.gg.uat.local.ComponentConfigTestService") == "FINISHED")
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /singleLevelKey: default value of singleLevelKey"
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /singleLevelKey: default value of singleLevelKey",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /nestedKey/leafKey: default value of /nestedKey/leafKey."
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /nestedKey/leafKey: default value of /nestedKey/leafKey.",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /nestedKey: {"leafKey":"default value of /nestedKey/leafKey"}. I will be interpolated as a serialized JSON String."
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /nestedKey: {\"leafKey\":\"default value of /nestedKey/leafKey\"}. I will be interpolated as a serialized JSON String.",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /listKey/0: item1."
+    # TODO: Add this after we support json pointer support for list indices. This logging has been removed from the component recipe for now.
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /emptyStringKey: ."
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /emptyStringKey: .",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /defaultIsNullKey: null"
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /defaultIsNullKey: null",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Value for /newSingleLevelKey: {configuration:/newSingleLevelKey}."
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Value for /newSingleLevelKey: {configuration:/newSingleLevelKey}.",
+        timeout=20) is True)
+
+    # And the aws.gg.uat.local.ComponentConfigTestService log contains the line "Verified JSON interpolation from script"
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl.aws.gg.uat.local.ComponentConfigTestService.service",
+        "Verified JSON interpolation from script",
+        timeout=20) is True)
+
+    # I can use greengrass-cli component details -n to check the component aws.gg.uat.local.ComponentConfigTestService has configuration that is equal to JSON:
+    #     """
+    #     {
+    #       "defaultIsNullKey": null,
+    #       "emptyListKey": [],
+    #       "emptyObjectKey": {},
+    #       "emptyStringKey": "",
+    #       "listKey": [
+    #         "item1",
+    #         "item2"
+    #       ],
+    #       "nestedKey": {
+    #         "leafKey": "default value of /nestedKey/leafKey"
+    #       },
+    #       "singleLevelKey": "default value of singleLevelKey",
+    #       "willBeNullKey": "I will be set to null soon"
+    #     }
+    #     """
+    # GG_LITE CLI doesn't support this yet.
+
+# As an operator, I can update component configurations from multiple sources, by doing a mix of cloud and local deployments.
+def test_Component_29_T4(gg_util_obj, system_interface):
+    # I upload component "aws.gg.uat.cloud.ComponentConfigTestService" version "1.0.0" from the local store
+    # I ensure component "aws.gg.uat.cloud.ComponentConfigTestService" version "1.0.0" exists on cloud with scope private within 60 seconds
+    component_cloud_name = gg_util_obj.upload_component_with_version(
+        "aws.gg.uat.cloud.ComponentConfigTestService", "1.0.0")
+
+    # I create a deployment configuration for deployment FirstCloudDeployment with components
+    #         | aws.gg.uat.cloud.ComponentConfigTestService | 1.0.0 |
+    # I deploy the configuration for deployment FirstCloudDeployment
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(config.thing_group_1),
+        [component_cloud_name], "FirstCloudDeployment")["deploymentId"]
+    assert deployment_id is not None
+
+    # the deployment FirstCloudDeployment completes with SUCCEEDED within 180 seconds
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "SUCCEEDED")
+
+    # I can check the cli to see the status of component aws.gg.uat.cloud.ComponentConfigTestService is FINISHED
+    assert (system_interface.check_systemctl_status_for_component(
+        "aws.gg.uat.cloud.ComponentConfigTestService") == "FINISHED")
+
+    # I can use greengrass-cli component details -n to check the component aws.gg.uat.cloud.ComponentConfigTestService has configuration that is equal to JSON:
+    # """
+    # {
+    #   "emptyListKey": [],
+    #   "emptyObjectKey": {},
+    #   "emptyStringKey": "",
+    #   "listKey": [
+    #     "item1",
+    #     "item2"
+    #   ],
+    #   "nestedKey": {
+    #     "leafKey": "default value of /nestedKey/leafKey"
+    #   },
+    #   "singleLevelKey": "default value of singleLevelKey",
+    #   "willBeNullKey": "I will be set to null soon",
+    #   "defaultIsNullKey": null
+    # }
+    # """
+    # GG_LITE CLI doesn't support this yet.
+
+    # I update the component aws.gg.uat.cloud.ComponentConfigTestService version 1.0.0 parameter singleLevelKey with value newValueForSingleLevelKey
+    # TODO: We do not support merge/reset configuration in local deployment.
+
+    # I can use greengrass-cli component details -n to check the component aws.gg.uat.cloud.ComponentConfigTestService has configuration that is equal to JSON:
+    # """
+    # {
+    #   "emptyListKey": [],
+    #   "emptyObjectKey": {},
+    #   "emptyStringKey": "",
+    #   "listKey": [
+    #     "item1",
+    #     "item2"
+    #   ],
+    #   "nestedKey": {
+    #     "leafKey": "default value of /nestedKey/leafKey"
+    #   },
+    #   "singleLevelKey": "newValueForSingleLevelKey",
+    #   "willBeNullKey": "I will be set to null soon",
+    #   "defaultIsNullKey": null
+    # }
+    # """
+    # GG_LITE CLI doesn't support this yet.
+
+    # I create an empty deployment configuration for deployment SecondCloudDeployment
+
+    # I update the deployment configuration SecondCloudDeployment, setting the component "aws.gg.uat.cloud.ComponentConfigTestService" version "1.0.0" configuration:
+    # """
+    # {
+    #   "RESET": ["/singleLevelKey"]
+    # }
+    # """
+
+    # I deploy the configuration for deployment SecondCloudDeployment
+
+    # the deployment SecondCloudDeployment completes with SUCCEEDED within 180 seconds
+
+    # I can check the cli to see the status of component aws.gg.uat.cloud.ComponentConfigTestService is FINISHED
+
+    # I can use greengrass-cli component details -n to check the component aws.gg.uat.cloud.ComponentConfigTestService has configuration that is equal to JSON:
+    # """
+    # {
+    #   "emptyListKey": [],
+    #   "emptyObjectKey": {},
+    #   "emptyStringKey": "",
+    #   "listKey": [
+    #     "item1",
+    #     "item2"
+    #   ],
+    #   "nestedKey": {
+    #     "leafKey": "default value of /nestedKey/leafKey"
+    #   },
+    #   "singleLevelKey": "default value of singleLevelKey",
+    #   "willBeNullKey": "I will be set to null soon",
+    #   "defaultIsNullKey": null
+    # }
+    # """
+    # GG_LITE CLI doesn't support this yet.
+
+# As a component developer, I can use automatic cleanup to delete component files further than last two deployments
+# Note: Heavily rewritten as GG_LITE only keeps files from the latest version.
+def test_Component_34_T4(gg_util_obj, system_interface):
+    # I install the component Minimal version 1.0.0 from local store
+    component_recipe_dir = "./components/Minimal/1.0.0/recipe/"
+    assert (gg_util_obj.create_local_deployment(
+        None, component_recipe_dir, "Minimal=1.0.0"))
+    # TODO: We can use the CLI to verify that a local deployment has finished once that feature exists
+    # For now, check if the expected component is running within a timeout.
+    timeout = 180
+    while timeout > 0:
+        if system_interface.check_systemctl_status_for_component(
+                "Minimal") == "RUNNING":
+            break
+        time.sleep(1)
+        timeout -= 1
+
+    # I install the component Minimal version 2.0.0 from local store
+    component_recipe_dir = "./components/Minimal/2.0.0/recipe/"
+    assert (gg_util_obj.create_local_deployment(
+        None, component_recipe_dir, "Minimal=2.0.0"))
+    # TODO: We can use the CLI to verify that a local deployment has finished once that feature exists
+    # For now, check if the expected component is running within a timeout.
+    timeout = 180
+    while timeout > 0:
+        if system_interface.check_systemctl_status_for_component(
+                "Minimal") == "RUNNING":
+            break
+        time.sleep(1)
+        timeout -= 1
+
+    # the local files for component Minimal version 2.0.0 should exist
+    # TODO: Replace hacky sleep when we can use CLI to verify a local deployment has finished.
+    time.sleep(30)
+    assert gg_util_obj.recipe_for_component_exists("Minimal", "2.0.0")
+
+    # the local files for component Minimal version 1.0.0 should not exist
+    assert not gg_util_obj.recipe_for_component_exists("Minimal", "1.0.0")

--- a/src/aws-greengrass-testing-fleet-status.py
+++ b/src/aws-greengrass-testing-fleet-status.py
@@ -10,7 +10,8 @@ def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
     gg_util = GGTestUtils(config.aws_account, config.s3_bucket_name,
-                          config.region, config.ggl_cli_bin_path)
+                          config.region, config.ggl_cli_bin_path,
+                          config.ggl_install_dir)
 
     # yield the instance of the class to the tests.
     yield gg_util

--- a/src/aws-greengrass-testing-security.py
+++ b/src/aws-greengrass-testing-security.py
@@ -10,7 +10,8 @@ def gg_util_obj():
     # Setup an instance of the GGUtils class. It is then passed to the
     # test functions.
     gg_util = GGTestUtils(config.aws_account, config.s3_bucket_name,
-                          config.region, config.ggl_cli_bin_path)
+                          config.region, config.ggl_cli_bin_path,
+                          config.ggl_install_dir)
 
     # yield the instance of the class to the tests.
     yield gg_util


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds Deployment-1-T6, Deployment-1-T12, Component-29-T0, Component-29-T4, and Component-34-T4.

Note that because local deployments requires a specific structure for the artifacts directory, there is a new local_artifacts folder that stores artifacts for local deployments rather than keeping them in their respective component directory. Eventually we may want to rethink our component directory structure.

Currently, Component-29-T0 and Component-29-T4 due possible bugs in GGL regarding handling recipe variable substitution when a configuration does not exist, and escaping quotes when adding to env variables. 

**Why is this change necessary:**
Add new tests

**How was this change tested:**
The tests all pass except for Component-29-T0 and Component-29-T4 which seems to be due to bugs in GGL rather than the tests themselves.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
