### PR TITLE
Add fleet status UATs for healthy, broken, removed, and uninstalled components

### DIFF
--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -902,6 +902,81 @@ class GGTestUtils:
 
         return False
 
+    def _resolve_single_thing_in_group(self,
+                                       thing_group_name: str) -> Optional[str]:
+        """Return the single thing name in a thing group, or None if the group
+        does not contain exactly one thing."""
+        things_in_group = self._iotClient.list_things_in_thing_group(
+            thingGroupName=thing_group_name,
+            recursive=False,
+            nextToken="",
+            maxResults=100,
+        )
+        things = things_in_group.get("things", [])
+        if len(things) != 1:
+            print("The number of things in the thing-group must be 1.")
+            return None
+        return things[0]
+
+    def get_cloud_installed_components(self, thing_name: str) -> Dict[str, str]:
+        """Return {componentName: lifecycleState} that the cloud reports as
+        installed on the core device via GreengrassV2 ListInstalledComponents.
+        A component removed from the device is pruned from this inventory once
+        fleet status reports it as UNINSTALLED, so it no longer appears."""
+        components: Dict[str, str] = {}
+        next_token = None
+        while True:
+            kwargs: Dict[str, Any] = {"coreDeviceThingName": thing_name}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = self._ggClient.list_installed_components(**kwargs)
+            for component in response.get("installedComponents", []):
+                components[component["componentName"]] = component.get(
+                    "lifecycleState", "")
+            next_token = response.get("nextToken")
+            if not next_token:
+                break
+        return components
+
+    def wait_for_cloud_component_installed(self,
+                                           timeout: int | float,
+                                           thing_group_name: str,
+                                           component_name: str,
+                                           thing_name: str = None) -> bool:
+        """Poll the cloud component inventory until `component_name` is reported
+        installed for the device, or the timeout elapses."""
+        if thing_name is None:
+            thing_name = self._resolve_single_thing_in_group(thing_group_name)
+        if thing_name is None:
+            return False
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if component_name in self.get_cloud_installed_components(
+                    thing_name):
+                return True
+            time.sleep(1)
+        return False
+
+    def wait_for_cloud_component_uninstalled(self,
+                                             timeout: int | float,
+                                             thing_group_name: str,
+                                             component_name: str,
+                                             thing_name: str = None) -> bool:
+        """Poll the cloud component inventory until `component_name` is no
+        longer reported for the device (pruned after fleet status reported it
+        as UNINSTALLED), or the timeout elapses."""
+        if thing_name is None:
+            thing_name = self._resolve_single_thing_in_group(thing_group_name)
+        if thing_name is None:
+            return False
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if component_name not in self.get_cloud_installed_components(
+                    thing_name):
+                return True
+            time.sleep(1)
+        return False
+
     def create_recipe_file(self, component_name: str) -> dict | None:
         template_file = os.path.join(".", "misc", "recipe_template.yaml")
         template_abs_path = os.path.abspath(template_file)

--- a/src/aws-greengrass-testing-fleet-status.py
+++ b/src/aws-greengrass-testing-fleet-status.py
@@ -1,6 +1,6 @@
 from typing import Generator
 from GGTestUtils import sleep_with_log
-from pytest import fixture, mark
+from pytest import fixture
 from src.IoTUtils import IoTUtils
 from src.GGTestUtils import GGTestUtils
 from src.SystemInterface import SystemInterface
@@ -87,8 +87,7 @@ def test_FleetStatus_1_T1(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
                                                   "HEALTHY"))
 
 
-#Scenario: FleetStatus-1-T3: As a customer I can get thing information with components whose statuses have changed after an IoT Jobs deployment fails
-@mark.skip(reason="TODO: Fix fleet status to update on GC failure")
+# Scenario: FleetStatus-1-T3: As a customer I can get thing information with components whose statuses have changed after an IoT Jobs deployment fails
 def test_FleetStatus_1_T3(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
                           system_interface: SystemInterface):
     # Get an auto generated thing group to which the thing is added.
@@ -122,3 +121,190 @@ def test_FleetStatus_1_T3(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
     #        | FssThingGroup |
     assert (gg_util_obj.wait_ggcore_device_status(180, fss_thing_group_name,
                                                   "UNHEALTHY"))
+
+
+# Scenario: FleetStatus-2-T2: Event-based FSS keeps the device HEALTHY when
+# a normal component reaches the RUNNING terminal state (no false UNHEALTHY
+# triggered by the broadcast of a non-failure terminal state).
+def test_FleetStatus_2_T2(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                          system_interface: SystemInterface):
+    # Given a thing group with the device added
+    fss_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    fss_thing_group_name = iot_obj.generate_thing_group_name(id)
+    fss_thing_group_result = iot_obj.add_thing_to_thing_group(
+        fss_thing_name, fss_thing_group_name)
+    assert fss_thing_group_result is True
+
+    # When I upload component "HelloWorld" version "1.0.0" (runs healthy)
+    component_cloud_name = gg_util_obj.upload_component_with_versions(
+        "HelloWorld", ["1.0.0"])
+    sleep_with_log(5)
+
+    # And I create and deploy a deployment with HelloWorld
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name),
+        [component_cloud_name],
+        "EventFssHealthyDeployment",
+    )["deploymentId"]
+    assert deployment_id is not None
+
+    # Then the deployment succeeds within 120s
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        120, deployment_id) == "SUCCEEDED")
+
+    # And the device reaches HEALTHY within 60s (component enters RUNNING)
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "HEALTHY"))
+
+    # Wait 20s past the event-based forwarding window to confirm the
+    # RUNNING terminal-state broadcast does NOT degrade the device status
+    sleep_with_log(20, "waiting past event-based forwarding window")
+
+    # Then the device is STILL HEALTHY — a RUNNING terminal-state
+    # broadcast must not cause a false UNHEALTHY via the event path
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "HEALTHY"))
+
+
+# Scenario: FleetStatus-1-T2: As a customer I can get thing information with
+# status of a BROKEN component
+# Derived from EvergreenFeatures fleet-status-1.feature
+def test_FleetStatus_1_T2(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                          system_interface: SystemInterface):
+    # Get an auto generated thing group to which the thing is added.
+    fss_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    fss_thing_group_name = iot_obj.generate_thing_group_name(id)
+    fss_thing_group_result = iot_obj.add_thing_to_thing_group(
+        fss_thing_name, fss_thing_group_name)
+    assert fss_thing_group_result is True
+
+    # When I upload component "BrokenComponent" version "1.0.0"
+    broken_cloud = gg_util_obj.upload_component_with_versions(
+        "BrokenComponent", ["1.0.0"])
+
+    # Give 5 sec for cloud to calculate artifact checksum and make it "DEPLOYABLE"
+    sleep_with_log(5)
+
+    # When I create and deploy deployment FirstDeployment with BrokenComponent
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name),
+        [broken_cloud],
+        "FirstDeployment",
+    )["deploymentId"]
+    assert deployment_id is not None
+
+    # Then the deployment FirstDeployment completes with FAILED within 180 seconds
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "FAILED")
+
+    # And the device thing status is UNHEALTHY within 60 seconds
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "UNHEALTHY"))
+
+
+# Scenario: FleetStatus-1-T5: Components which were removed after an IoT Jobs
+# deployment succeeds
+# Derived from EvergreenFeatures fleet-status-1.feature
+def test_FleetStatus_1_T5(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                          system_interface: SystemInterface):
+    # Get an auto generated thing group to which the thing is added.
+    fss_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    fss_thing_group_name = iot_obj.generate_thing_group_name(id)
+    fss_thing_group_result = iot_obj.add_thing_to_thing_group(
+        fss_thing_name, fss_thing_group_name)
+    assert fss_thing_group_result is True
+
+    # When I upload component "HelloWorld" version "1.0.0"
+    component_cloud = gg_util_obj.upload_component_with_versions(
+        "HelloWorld", ["1.0.0"])
+
+    # Give 5 sec for cloud to calculate artifact checksum and make it "DEPLOYABLE"
+    sleep_with_log(5)
+
+    # When I create and deploy deployment FirstDeployment with HelloWorld
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name),
+        [component_cloud],
+        "FirstDeployment",
+    )["deploymentId"]
+    assert deployment_id is not None
+
+    # Then the deployment FirstDeployment completes with SUCCEEDED within 180 seconds
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "SUCCEEDED")
+
+    # And the device is HEALTHY within 60 seconds
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "HEALTHY"))
+
+    # When I create an empty deployment removing all components
+    removal_result = gg_util_obj.remove_all_components(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name))
+
+    # Then the removal deployment completes with SUCCEEDED
+    assert removal_result == "SUCCEEDED"
+
+    # And the device is still HEALTHY within 60 seconds
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "HEALTHY"))
+
+
+# Scenario: FleetStatus-UninstalledReporting-T1: When a deployment fully
+# removes a component, fleet status reports it to the cloud as UNINSTALLED so
+# the cloud prunes it from the device's installed-component inventory.
+# Validates aws-greengrass-lite commit c50aec3b ("Add support for reporting
+# stale components as UNINSTALLED in fleet status"). Derived from the
+# component-removal flow in EvergreenFeatures fleet-status-1.feature (T5).
+def test_FleetStatus_UninstalledReporting_T1(iot_obj: IoTUtils,
+                                             gg_util_obj: GGTestUtils,
+                                             system_interface: SystemInterface):
+    # Get an auto generated thing group to which the thing is added.
+    fss_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    fss_thing_group_name = iot_obj.generate_thing_group_name(id)
+    fss_thing_group_result = iot_obj.add_thing_to_thing_group(
+        fss_thing_name, fss_thing_group_name)
+    assert fss_thing_group_result is True
+
+    # When I upload component "HelloWorld" version "1.0.0"
+    component_cloud = gg_util_obj.upload_component_with_versions(
+        "HelloWorld", ["1.0.0"])
+
+    # Give 5 sec for cloud to calculate artifact checksum and make it "DEPLOYABLE"
+    sleep_with_log(5)
+
+    # And I deploy a deployment with HelloWorld to the thing group
+    deployment_id = gg_util_obj.create_deployment(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name),
+        [component_cloud],
+        "FirstDeployment",
+    )["deploymentId"]
+    assert deployment_id is not None
+
+    # Then the deployment completes with SUCCEEDED within 180 seconds
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "SUCCEEDED")
+
+    # And the device is HEALTHY within 60 seconds
+    assert (gg_util_obj.wait_ggcore_device_status(60, fss_thing_group_name,
+                                                  "HEALTHY"))
+
+    # And the cloud reports the component as installed within 60 seconds
+    # (use the randomized cloud component name, not the local recipe name)
+    assert (gg_util_obj.wait_for_cloud_component_installed(
+        60, fss_thing_group_name, component_cloud.name))
+
+    # When I create an empty deployment that removes all components
+    removal_result = gg_util_obj.remove_all_components(
+        gg_util_obj.get_thing_group_arn(fss_thing_group_name))
+
+    # Then the removal deployment completes with SUCCEEDED
+    assert removal_result == "SUCCEEDED"
+
+    # And the cloud prunes the component from the device inventory within 90s
+    # because fleet status reported it as UNINSTALLED on the removal update
+    assert (gg_util_obj.wait_for_cloud_component_uninstalled(
+        90, fss_thing_group_name, component_cloud.name))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add four fleet status tests, three of which are derived from EvergreenFeatures fleet-status-1.feature, plus a regression test for UNINSTALLED reporting:

- test_FleetStatus_1_T2: BROKEN component reports UNHEALTHY.
- test_FleetStatus_1_T5: device stays HEALTHY after component removal.
- test_FleetStatus_2_T2: RUNNING terminal-state broadcast does not trigger a false UNHEALTHY via the event-based path.
- test_FleetStatus_UninstalledReporting_T1: removed components are reported to the cloud as UNINSTALLED so the cloud prunes them from the device's installed-component inventory (validates aws-greengrass-lite commit c50aec3b).

Unskip test_FleetStatus_1_T3 now that fleet status updates on GC failure.

Add GGTestUtils helpers backing the new tests:

- get_cloud_installed_components: ListInstalledComponents wrapper returning {componentName: lifecycleState}.
- wait_for_cloud_component_installed / _uninstalled: poll the cloud inventory until the component appears or is pruned.
- _resolve_single_thing_in_group: resolve the single device thing from a thing group.

**Why is this change necessary:**
Covers tests for the features from https://github.com/aws-greengrass/aws-greengrass-lite/pull/1128 and https://github.com/aws-greengrass/aws-greengrass-lite/pull/1125

**How was this change tested:**
By running the
<img width="444" height="312" alt="Screenshot 2026-06-15 at 5 27 19 PM" src="https://github.com/user-attachments/assets/e9ef1d2e-d6e9-4382-880d-ce6e198b1313" />
 Podman container:


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
