### PR TITLE
Fix ConfigUpdateSubscriber UAT to use randomized component name

### DIFF
--- a/components/ConfigUpdateSubscriber/1.0.0/artifacts/config_update_subscriber.py
+++ b/components/ConfigUpdateSubscriber/1.0.0/artifacts/config_update_subscriber.py
@@ -1,0 +1,50 @@
+import time
+from sys import stderr
+from traceback import print_exc
+
+from awsiot.greengrasscoreipc.clientv2 import GreengrassCoreIPCClientV2
+from awsiot.greengrasscoreipc.model import ConfigurationUpdateEvents
+
+
+def _on_event(event: ConfigurationUpdateEvents) -> None:
+    try:
+        e = event.configuration_update_event
+        key_path = "/".join(e.key_path) if e.key_path else ""
+        # Unique marker the UAT greps for.
+        print(
+            f"CONFIG_UPDATE_RECEIVED component={e.component_name} "
+            f"keyPath={key_path}",
+            flush=True)
+    except Exception:
+        print_exc()
+
+
+def _on_error(error: Exception) -> bool:
+    print("Config update stream error.", file=stderr)
+    print_exc()
+    return False
+
+
+def _on_closed() -> None:
+    print("Config update stream closed.", flush=True)
+
+
+def main() -> None:
+    try:
+        ipc = GreengrassCoreIPCClientV2()
+        _, op = ipc.subscribe_to_configuration_update(
+            key_path=[],
+            on_stream_event=_on_event,
+            on_stream_error=_on_error,
+            on_stream_closed=_on_closed,
+        )
+        print("CONFIG_UPDATE_SUBSCRIBED", flush=True)
+        while True:
+            time.sleep(10)
+    except Exception:
+        print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/ConfigUpdateSubscriber/1.0.0/recipe/ConfigUpdateSubscriber-1.0.0.yaml
+++ b/components/ConfigUpdateSubscriber/1.0.0/recipe/ConfigUpdateSubscriber-1.0.0.yaml
@@ -29,4 +29,6 @@ Manifests:
         .venv/bin/python3 -m pip install awsiotsdk
       run: |-
         .venv/bin/python3 -u {artifacts:path}/config_update_subscriber.py
+    Artifacts:
+      - URI: "s3://$bucketName$/$testArtifactsDirectory$/$randomId$/config_update_subscriber.py"
 Lifecycle: {}

--- a/src/aws-greengrass-testing-config-subscription.py
+++ b/src/aws-greengrass-testing-config-subscription.py
@@ -88,7 +88,6 @@ def test_ConfigUpdateSubscription_no_duplicate_on_repeat_deploy(
         system_interface: SystemInterface):
     component = "ConfigUpdateSubscriber"
     version = "1.0.0"
-    service = f"ggl.{component}.service"
     marker = "CONFIG_UPDATE_RECEIVED"
 
     # Add the core device's thing to a new thing group so we can target it
@@ -99,9 +98,14 @@ def test_ConfigUpdateSubscription_no_duplicate_on_repeat_deploy(
                                             thing_group_name) is True
     thing_group_arn = gg_util_obj.get_thing_group_arn(thing_group_name)
 
-    # Upload the component once. All subsequent deployments reuse this same
-    # version and vary only the merged configuration.
-    gg_util_obj.upload_component_with_versions(component, [version])
+    # Upload the component once. The framework registers it in the cloud under
+    # a randomized name (e.g. "ConfigUpdateSubscriber<uuid>"), so reuse that
+    # returned name for every deployment and on-device (systemd) lookup. All
+    # subsequent deployments reuse this same version and vary only the merged
+    # configuration.
+    component = gg_util_obj.upload_component_with_versions(
+        component, [version]).name
+    service = f"ggl.{component}.service"
     sleep_with_log(5, "let cloud mark the component DEPLOYABLE")
 
     # First deployment: component starts and subscribes. The default config is


### PR DESCRIPTION
- Declare the artifact in the recipe and add the missing config_update_subscriber.py script.
- upload_component_with_versions returns a randomized component name; use it for the deployment target and ggl.<name>.service lookup.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
The changes were tested by running them locally

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
