### PR TITLE
Fix UAT throttle swallowing and false passes

### DIFF
--- a/src/GGLSetup.py
+++ b/src/GGLSetup.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 from uuid import uuid1
 from boto3 import client
 import boto3
+from botocore.config import Config
 import time
 import logging
 import yaml
@@ -27,6 +28,10 @@ PRIVATE_PATH = "/var/lib/greengrass/private.pem.key"
 CA_PATH = "/var/lib/greengrass/AmazonRootCA1.pem"
 JSON_FILE = "/tmp/aws-greengrass-testing-workspace/iot_setup_data.json"
 WORKSPACE_DIR = "/tmp/aws-greengrass-testing-workspace"
+
+# Adaptive retry config: adds client-side rate limiting/backoff to absorb
+# IoT Core / GGv2 API throttling under parallel UAT load.
+THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
 
 
 def download_greengrass_lite(commit_id: str) -> bool:
@@ -87,7 +92,7 @@ def setup_greengrass_lite(commit_id: str, region: str):
     os.chdir(ggl_path)
 
     # Set up an iot client
-    iot_client = client("iot", region_name=region)
+    iot_client = client("iot", region_name=region, config=THROTTLE_RETRY_CONFIG)
 
     try:
 
@@ -175,7 +180,7 @@ def setup_greengrass_lite(commit_id: str, region: str):
             raise Exception(
                 f"FATAL: Could not read thing name from config: {e}")
 
-        gg_client = boto3.client('greengrassv2')
+        gg_client = boto3.client('greengrassv2', config=THROTTLE_RETRY_CONFIG)
 
         for attempt in range(30):    # Wait up to 5 minutes
             try:

--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -6,6 +6,7 @@ import boto3
 from botocore.exceptions import ClientError, BotoCoreError
 from botocore.config import Config
 import time
+import random
 import logging
 import subprocess
 from types_boto3_greengrassv2 import GreengrassV2Client
@@ -26,13 +27,50 @@ RECIPE_DIR = "/var/lib/greengrass/packages/recipes"
 THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
 
 # Exponential backoff bounds for deployment poll loop (seconds)
-INITIAL_POLL_INTERVAL = 2  # start polling every 2s instead of 1s
-MAX_POLL_INTERVAL = 15  # cap backoff at 15s to stay responsive
-MAX_CONSECUTIVE_DEPLOYMENT_ERRORS = 3  # consecutive failed status checks before failing loudly
+INITIAL_POLL_INTERVAL = 2    # start polling every 2s instead of 1s
+MAX_POLL_INTERVAL = 15    # cap backoff at 15s to stay responsive
+MAX_CONSECUTIVE_DEPLOYMENT_ERRORS = 3    # consecutive failed status checks before failing loudly
 
 # Delay between destructive teardown calls to ease IoT Jobs
 # DELETION_IN_PROGRESS concurrency limits.
-TEARDOWN_CALL_DELAY = 0.5  # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
+TEARDOWN_CALL_DELAY = 0.5    # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
+
+# Retryable throttling error codes from AWS APIs.
+_THROTTLE_CODES = frozenset({
+    "ThrottlingException",
+    "Throttling",
+    "ThrottledException",
+    "TooManyRequestsException",
+    "RequestLimitExceeded",
+    "LimitExceededException",
+})
+
+
+def _retry_on_throttle(func, *, attempts=3, base_delay=1.0, cap=10.0):
+    """Retry func() on throttling/transient errors with full-jitter backoff.
+
+    Non-throttle ClientErrors (e.g. ResourceNotFoundException) re-raise immediately.
+    """
+    for attempt in range(attempts):
+        try:
+            return func()
+        except ClientError as e:
+            code = e.response["Error"].get("Code", "")
+            if code not in _THROTTLE_CODES or attempt == attempts - 1:
+                raise
+            delay = random.uniform(0, min(base_delay * 2**attempt, cap))
+            print(
+                f"  Throttled ({code}), retry {attempt + 1}/{attempts} after {delay:.1f}s"
+            )
+            time.sleep(delay)
+        except BotoCoreError:
+            if attempt == attempts - 1:
+                raise
+            delay = random.uniform(0, min(base_delay * 2**attempt, cap))
+            print(
+                f"  Transient error, retry {attempt + 1}/{attempts} after {delay:.1f}s"
+            )
+            time.sleep(delay)
 
 
 def sleep_with_log(seconds: int, reason: str = ""):
@@ -70,9 +108,15 @@ class GGTestUtils:
         self._account = account
         self._bucket = bucket
         self._cli_bin_path = cli_bin_path
-        self._ggClient = boto3.client("greengrassv2", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
-        self._iotClient = boto3.client("iot", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
-        self._s3Client = boto3.client("s3", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._ggClient = boto3.client("greengrassv2",
+                                      region_name=self._region,
+                                      config=THROTTLE_RETRY_CONFIG)
+        self._iotClient = boto3.client("iot",
+                                       region_name=self._region,
+                                       config=THROTTLE_RETRY_CONFIG)
+        self._s3Client = boto3.client("s3",
+                                      region_name=self._region,
+                                      config=THROTTLE_RETRY_CONFIG)
         self._ggComponentToDeleteArn = []
         self._component_random_ids = {
         }    # Track random_id per component-version
@@ -202,7 +246,9 @@ class GGTestUtils:
             }
 
         except (ClientError, BotoCoreError) as e:
-            if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+            if isinstance(
+                    e, ClientError
+            ) and e.response["Error"]["Code"] == "ResourceNotFoundException":
                 # Benign: deployment not queryable yet (eventual consistency).
                 print(f"Deployment {deployment_id} not found")
                 return None
@@ -382,13 +428,13 @@ class GGTestUtils:
     def wait_for_deployment_till_timeout(
             self, timeout: float,
             deployment_id: str) -> Literal['SUCCEEDED', 'FAILED', 'TIMEOUT']:
-        poll_interval = INITIAL_POLL_INTERVAL  # exponential backoff starting point
-        consecutive_errors = 0  # consecutive failed status checks (e.g. throttling)
+        poll_interval = INITIAL_POLL_INTERVAL    # exponential backoff starting point
+        consecutive_errors = 0    # consecutive failed status checks (e.g. throttling)
         while timeout > 0:
             try:
                 result = self._check_greengrass_group_deployment_status(
                     deployment_id)
-                consecutive_errors = 0  # a clean call resets the counter
+                consecutive_errors = 0    # a clean call resets the counter
             except (ClientError, BotoCoreError) as e:
                 # The status check surfaced a real API error (e.g. a
                 # ThrottlingException that survived adaptive retries). Do NOT
@@ -402,11 +448,12 @@ class GGTestUtils:
                 if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
                     print(
                         f"Persistent API errors checking deployment "
-                        f"{deployment_id}; failing instead of silently timing out.")
+                        f"{deployment_id}; failing instead of silently timing out."
+                    )
                     return "FAILED"
                 sleep_for = min(poll_interval, timeout)
-                sleep_with_log(
-                    sleep_for, "backing off after deployment status error")
+                sleep_with_log(sleep_for,
+                               "backing off after deployment status error")
                 timeout -= sleep_for
                 poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
                 continue
@@ -547,7 +594,8 @@ class GGTestUtils:
                     print(f"{'='*60}\n")
                     return "FAILED"
             except (ClientError, BotoCoreError) as e:
-                if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+                if isinstance(e, ClientError) and e.response["Error"][
+                        "Code"] == "ResourceNotFoundException":
                     # Benign: job execution not queryable yet.
                     pass
                 else:
@@ -557,10 +605,13 @@ class GGTestUtils:
                         f"({consecutive_errors}/{MAX_CONSECUTIVE_DEPLOYMENT_ERRORS}) "
                         f"for {iot_job_id}: {e}")
                     if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
-                        print(f"Persistent API errors checking IoT job {iot_job_id}; failing.")
+                        print(
+                            f"Persistent API errors checking IoT job {iot_job_id}; failing."
+                        )
                         return "FAILED"
                     sleep_for = min(poll_interval, timeout)
-                    sleep_with_log(sleep_for, "backing off after iot job status error")
+                    sleep_with_log(sleep_for,
+                                   "backing off after iot job status error")
                     timeout -= sleep_for
                     poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
                     continue
@@ -897,7 +948,8 @@ class GGTestUtils:
                 self._ggClient.delete_component(arn=componentArn)
             except Exception as e:
                 logging.warning(
-                    f'Failed to delete component {componentArn} from configured test account: {e}')
+                    f'Failed to delete component {componentArn} from configured test account: {e}'
+                )
             time.sleep(TEARDOWN_CALL_DELAY)
 
         # Delete S3 artifacts for each component random_id
@@ -941,11 +993,18 @@ class GGTestUtils:
                 print(
                     f"Cleaning up deployment: {deployment}, with thing group arn: {thing_group_arn}"
                 )
-                self._ggClient.cancel_deployment(deploymentId=deployment)
+                _retry_on_throttle(lambda d=deployment: self._ggClient.
+                                   cancel_deployment(deploymentId=d))
             except Exception as e:
                 print(f"Failed to cancel deployment {deployment}: {e}")
             try:
-                self._ggClient.delete_deployment(deploymentId=deployment)
+                # Highest-contention call — hits IoT Jobs DELETION_IN_PROGRESS 10-cap;
+                # use extended budget to wait out slot drains (30-60s).
+                _retry_on_throttle(lambda d=deployment: self._ggClient.
+                                   delete_deployment(deploymentId=d),
+                                   attempts=5,
+                                   base_delay=2.0,
+                                   cap=30.0)
             except Exception as e:
                 print(f"Failed to delete deployment {deployment}: {e}")
             time.sleep(TEARDOWN_CALL_DELAY)
@@ -987,7 +1046,8 @@ class GGTestUtils:
                     coreDeviceThingName=thing_name)
                 consecutive_errors = 0
             except (ClientError, BotoCoreError) as e:
-                if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+                if isinstance(e, ClientError) and e.response["Error"][
+                        "Code"] == "ResourceNotFoundException":
                     # Benign: core device not registered yet.
                     return_val = None
                 else:
@@ -997,10 +1057,13 @@ class GGTestUtils:
                         f"({consecutive_errors}/{MAX_CONSECUTIVE_DEPLOYMENT_ERRORS}) "
                         f"for {thing_name}: {e}")
                     if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
-                        print(f"Persistent API errors checking core device {thing_name}; failing.")
+                        print(
+                            f"Persistent API errors checking core device {thing_name}; failing."
+                        )
                         return False
                     sleep_for = min(poll_interval, timeout)
-                    sleep_with_log(sleep_for, "backing off after core device status error")
+                    sleep_with_log(
+                        sleep_for, "backing off after core device status error")
                     timeout -= sleep_for
                     poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
                     continue

--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -3,7 +3,8 @@ import os
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 from uuid import uuid1
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, BotoCoreError
+from botocore.config import Config
 import time
 import logging
 import subprocess
@@ -19,6 +20,19 @@ from typing import Sequence, Optional, Any, Dict, List, Literal, Optional, Seque
 
 S3_ARTIFACT_DIR = "artifacts"
 RECIPE_DIR = "/var/lib/greengrass/packages/recipes"
+
+# Adaptive retry config: adds client-side rate limiting/backoff to absorb
+# IoT Core / GGv2 API throttling under parallel UAT load.
+THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
+
+# Exponential backoff bounds for deployment poll loop (seconds)
+INITIAL_POLL_INTERVAL = 2  # start polling every 2s instead of 1s
+MAX_POLL_INTERVAL = 15  # cap backoff at 15s to stay responsive
+MAX_CONSECUTIVE_DEPLOYMENT_ERRORS = 3  # consecutive failed status checks before failing loudly
+
+# Delay between destructive teardown calls to ease IoT Jobs
+# DELETION_IN_PROGRESS concurrency limits.
+TEARDOWN_CALL_DELAY = 0.5  # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
 
 
 def sleep_with_log(seconds: int, reason: str = ""):
@@ -56,9 +70,9 @@ class GGTestUtils:
         self._account = account
         self._bucket = bucket
         self._cli_bin_path = cli_bin_path
-        self._ggClient = boto3.client("greengrassv2", region_name=self._region)
-        self._iotClient = boto3.client("iot", region_name=self._region)
-        self._s3Client = boto3.client("s3", region_name=self._region)
+        self._ggClient = boto3.client("greengrassv2", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._iotClient = boto3.client("iot", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._s3Client = boto3.client("s3", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
         self._ggComponentToDeleteArn = []
         self._component_random_ids = {
         }    # Track random_id per component-version
@@ -103,6 +117,10 @@ class GGTestUtils:
                 thingGroupName=thing_group_name)
             things = [thing for thing in response.get("things", [])]
             return things
+        except (ClientError, BotoCoreError):
+            # Surface AWS errors (incl. persistent throttling) so callers fail
+            # loudly instead of returning None and crashing on iteration.
+            raise
         except Exception as e:
             print(f"Error retrieving things in thing group: {e}")
             return None
@@ -133,6 +151,11 @@ class GGTestUtils:
                 # If this is a thing instead of a thing group.
                 things_list.append(target_arn.split("/")[-1])
 
+            if things_list is None:
+                # Defensive: a non-AWS error path returned None; treat as no
+                # things rather than crashing on `for thing in things_list`.
+                things_list = []
+
             statistics_list = []
 
             for thing in things_list:
@@ -160,6 +183,11 @@ class GGTestUtils:
                         if statistic:
                             statistics_list.append({thing: statistic})
 
+                except (ClientError, BotoCoreError):
+                    # Surface ALL AWS SDK errors (throttling, auth, connection,
+                    # timeouts, etc.) to the caller's fail-loud counter instead
+                    # of masking them as "stats not ready yet".
+                    raise
                 except Exception as e:
                     elapsed = int(time.time() - start_time)
                     print(
@@ -173,12 +201,17 @@ class GGTestUtils:
                 "statistics": statistics_list,
             }
 
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+        except (ClientError, BotoCoreError) as e:
+            if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+                # Benign: deployment not queryable yet (eventual consistency).
                 print(f"Deployment {deployment_id} not found")
-            else:
-                print(f"An error occurred: {e}")
-            return None
+                return None
+            # Previously ALL other ClientErrors (incl. ThrottlingException) were
+            # swallowed via `return None`, which the caller read as "not ready
+            # yet" -> silent timeout / false PASS. Surface it so the caller can
+            # fail loudly on persistent errors.
+            print(f"An error occurred: {e}")
+            raise
 
     def create_local_deployment(self,
                                 artifacts_dir,
@@ -349,9 +382,34 @@ class GGTestUtils:
     def wait_for_deployment_till_timeout(
             self, timeout: float,
             deployment_id: str) -> Literal['SUCCEEDED', 'FAILED', 'TIMEOUT']:
+        poll_interval = INITIAL_POLL_INTERVAL  # exponential backoff starting point
+        consecutive_errors = 0  # consecutive failed status checks (e.g. throttling)
         while timeout > 0:
-            result = self._check_greengrass_group_deployment_status(
-                deployment_id)
+            try:
+                result = self._check_greengrass_group_deployment_status(
+                    deployment_id)
+                consecutive_errors = 0  # a clean call resets the counter
+            except (ClientError, BotoCoreError) as e:
+                # The status check surfaced a real API error (e.g. a
+                # ThrottlingException that survived adaptive retries). Do NOT
+                # silently keep polling: count it and fail loudly if it persists,
+                # so a throttled run goes RED instead of false-passing.
+                consecutive_errors += 1
+                print(
+                    f"Deployment status check failed "
+                    f"({consecutive_errors}/{MAX_CONSECUTIVE_DEPLOYMENT_ERRORS}) "
+                    f"for {deployment_id}: {e}")
+                if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
+                    print(
+                        f"Persistent API errors checking deployment "
+                        f"{deployment_id}; failing instead of silently timing out.")
+                    return "FAILED"
+                sleep_for = min(poll_interval, timeout)
+                sleep_with_log(
+                    sleep_for, "backing off after deployment status error")
+                timeout -= sleep_for
+                poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
+                continue
             if result:
                 if result["statistics"]:
                     for entry in result["statistics"]:
@@ -449,8 +507,11 @@ class GGTestUtils:
                                     else:
                                         pass
 
-            time.sleep(1)
-            timeout -= 1
+            # Exponential backoff: reduce API pressure under parallel UAT load
+            sleep_for = min(poll_interval, timeout)
+            sleep_with_log(sleep_for, "polling deployment status")
+            timeout -= sleep_for
+            poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
 
         return "TIMEOUT"
 
@@ -464,10 +525,13 @@ class GGTestUtils:
             print(f"No iotJobId found for deployment {deployment_id}")
             return "FAILED"
 
+        poll_interval = INITIAL_POLL_INTERVAL
+        consecutive_errors = 0
         while timeout > 0:
             try:
                 resp = self._iotClient.describe_job_execution(
                     jobId=iot_job_id, thingName=thing_name)
+                consecutive_errors = 0
                 execution = resp["execution"]
                 status = execution["status"]
                 if status == "SUCCEEDED":
@@ -482,10 +546,29 @@ class GGTestUtils:
                     self._dump_device_logs()
                     print(f"{'='*60}\n")
                     return "FAILED"
-            except Exception as e:
-                print(f"Error checking job status: {e}")
-            time.sleep(1)
-            timeout -= 1
+            except (ClientError, BotoCoreError) as e:
+                if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+                    # Benign: job execution not queryable yet.
+                    pass
+                else:
+                    consecutive_errors += 1
+                    print(
+                        f"IoT job status check failed "
+                        f"({consecutive_errors}/{MAX_CONSECUTIVE_DEPLOYMENT_ERRORS}) "
+                        f"for {iot_job_id}: {e}")
+                    if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
+                        print(f"Persistent API errors checking IoT job {iot_job_id}; failing.")
+                        return "FAILED"
+                    sleep_for = min(poll_interval, timeout)
+                    sleep_with_log(sleep_for, "backing off after iot job status error")
+                    timeout -= sleep_for
+                    poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
+                    continue
+
+            sleep_for = min(poll_interval, timeout)
+            sleep_with_log(sleep_for, "polling iot job status")
+            timeout -= sleep_for
+            poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
 
         return "TIMEOUT"
 
@@ -809,12 +892,13 @@ class GGTestUtils:
 
     def cleanup(self) -> None:
         for componentArn in self._ggComponentToDeleteArn:
+            # Isolate each delete so one failure doesn't skip the rest.
             try:
                 self._ggClient.delete_component(arn=componentArn)
-            except:
+            except Exception as e:
                 logging.warning(
-                    f'Failed to delete component {componentArn} from configured test account.'
-                )
+                    f'Failed to delete component {componentArn} from configured test account: {e}')
+            time.sleep(TEARDOWN_CALL_DELAY)
 
         # Delete S3 artifacts for each component random_id
         for random_id in set(self._component_random_ids.values()):
@@ -852,14 +936,19 @@ class GGTestUtils:
                 print(e)
 
         for (deployment, thing_group_arn) in self._ggDeploymentToThingNameList:
+            # Isolate each deployment cancel+delete so one failure continues to the next.
             try:
                 print(
                     f"Cleaning up deployment: {deployment}, with thing group arn: {thing_group_arn}"
                 )
                 self._ggClient.cancel_deployment(deploymentId=deployment)
+            except Exception as e:
+                print(f"Failed to cancel deployment {deployment}: {e}")
+            try:
                 self._ggClient.delete_deployment(deploymentId=deployment)
             except Exception as e:
-                print(e)
+                print(f"Failed to delete deployment {deployment}: {e}")
+            time.sleep(TEARDOWN_CALL_DELAY)
 
         # Reset the lists.
         self._ggComponentToDeleteArn = []
@@ -890,13 +979,37 @@ class GGTestUtils:
                 return False
             thing_name = things_in_group["things"][0]
 
+        poll_interval = INITIAL_POLL_INTERVAL
+        consecutive_errors = 0
         while timeout > 0:
-            return_val = self._ggClient.get_core_device(
-                coreDeviceThingName=thing_name)
+            try:
+                return_val = self._ggClient.get_core_device(
+                    coreDeviceThingName=thing_name)
+                consecutive_errors = 0
+            except (ClientError, BotoCoreError) as e:
+                if isinstance(e, ClientError) and e.response["Error"]["Code"] == "ResourceNotFoundException":
+                    # Benign: core device not registered yet.
+                    return_val = None
+                else:
+                    consecutive_errors += 1
+                    print(
+                        f"Core device status check failed "
+                        f"({consecutive_errors}/{MAX_CONSECUTIVE_DEPLOYMENT_ERRORS}) "
+                        f"for {thing_name}: {e}")
+                    if consecutive_errors >= MAX_CONSECUTIVE_DEPLOYMENT_ERRORS:
+                        print(f"Persistent API errors checking core device {thing_name}; failing.")
+                        return False
+                    sleep_for = min(poll_interval, timeout)
+                    sleep_with_log(sleep_for, "backing off after core device status error")
+                    timeout -= sleep_for
+                    poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
+                    continue
 
             if return_val is None or return_val["status"] != desired_health:
-                time.sleep(1)
-                timeout -= 1
+                sleep_for = min(poll_interval, timeout)
+                sleep_with_log(sleep_for, "polling core device status")
+                timeout -= sleep_for
+                poll_interval = min(poll_interval * 2, MAX_POLL_INTERVAL)
             else:
                 return True
 

--- a/src/IoTUtils.py
+++ b/src/IoTUtils.py
@@ -3,11 +3,49 @@ from typing import List, Optional
 from boto3 import client
 from types_boto3_iot import IoTClient
 import botocore
+from botocore.config import Config
+from botocore.exceptions import ClientError, BotoCoreError
 import json
+import random
 import subprocess
 import uuid
 
 JSON_FILE = "/tmp/aws-greengrass-testing-workspace/iot_setup_data.json"
+
+# Adaptive retry config: adds client-side rate limiting/backoff to absorb
+# IoT Core / GGv2 API throttling under parallel UAT load.
+THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
+
+TEARDOWN_CALL_DELAY = 0.5  # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
+
+# Retryable throttling error codes from AWS APIs.
+_THROTTLE_CODES = frozenset({
+    "ThrottlingException", "Throttling", "ThrottledException",
+    "TooManyRequestsException", "RequestLimitExceeded", "LimitExceededException",
+})
+
+
+def _retry_on_throttle(func, *, attempts=3, base_delay=1.0, cap=10.0):
+    """Retry func() on throttling/transient errors with full-jitter backoff.
+
+    Non-throttle ClientErrors (e.g. ResourceNotFoundException) re-raise immediately.
+    """
+    for attempt in range(attempts):
+        try:
+            return func()
+        except ClientError as e:
+            code = e.response["Error"].get("Code", "")
+            if code not in _THROTTLE_CODES or attempt == attempts - 1:
+                raise  # non-retryable or final attempt — propagate
+            delay = random.uniform(0, min(base_delay * 2 ** attempt, cap))
+            print(f"  Throttled ({code}), retry {attempt + 1}/{attempts} after {delay:.1f}s")
+            sleep(delay)
+        except (BotoCoreError, botocore.exceptions.ConnectionError):
+            if attempt == attempts - 1:
+                raise
+            delay = random.uniform(0, min(base_delay * 2 ** attempt, cap))
+            print(f"  Transient error, retry {attempt + 1}/{attempts} after {delay:.1f}s")
+            sleep(delay)
 
 
 class IoTUtils():
@@ -15,9 +53,9 @@ class IoTUtils():
     def __init__(self, region: str, thing_name: str = None):
         self._region = region
         self._thing_name = thing_name
-        self._iot_client = client("iot", region_name=self._region)
-        self._iam_client = client("iam", region_name=self._region)
-        self._gg_client = client("greengrassv2", region_name=self._region)
+        self._iot_client = client("iot", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._iam_client = client("iam", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._gg_client = client("greengrassv2", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
         self._thing_groups = []
         self._provisioned_role_name = None
         self._provisioned_role_alias = None
@@ -183,8 +221,13 @@ class IoTUtils():
                 print("No deployments found to cancel")
             else:
                 for deployment in deployments['effectiveDeployments']:
-                    self._gg_client.cancel_deployment(
-                        deploymentId=deployment['deploymentId'])
+                    # Isolate each cancel so one throttle/error doesn't abort the rest.
+                    try:
+                        self._gg_client.cancel_deployment(
+                            deploymentId=deployment['deploymentId'])
+                    except Exception as e:
+                        print(f"Failed to cancel deployment {deployment['deploymentId']}: {e}")
+                    sleep(TEARDOWN_CALL_DELAY)
                 print(f"Cancelled all deployments")
 
         except Exception as e:
@@ -193,8 +236,9 @@ class IoTUtils():
 
         # Delete the core device
         try:
-            self._gg_client.delete_core_device(
-                coreDeviceThingName=self._thing_name)
+            _retry_on_throttle(
+                lambda: self._gg_client.delete_core_device(
+                    coreDeviceThingName=self._thing_name))
             print(f"Deleted Greengrass core device '{self._thing_name}'")
         except Exception as e:
             print(f"Failed to delete Greengrass core device: {str(e)}")
@@ -208,32 +252,38 @@ class IoTUtils():
             principals = self._iot_client.list_thing_principals(
                 thingName=thing_name)['principals']
 
-            # For each certificate attached to the thing
+            # For each certificate attached to the thing — isolate each so
+            # a failure on one cert doesn't leak the others.
             for principal in principals:
-                cert_id = principal.split('/')[-1]
+                try:
+                    cert_id = principal.split('/')[-1]
 
-                # Detach all policies from the certificate
-                policies = self._iot_client.list_attached_policies(
-                    target=principal)['policies']
+                    # Detach all policies from the certificate
+                    policies = self._iot_client.list_attached_policies(
+                        target=principal)['policies']
 
-                for policy in policies:
-                    self._iot_client.detach_policy(
-                        policyName=policy['policyName'], target=principal)
+                    for policy in policies:
+                        self._iot_client.detach_policy(
+                            policyName=policy['policyName'], target=principal)
 
-                # Detach certificate from thing
-                self._iot_client.detach_thing_principal(thingName=thing_name,
-                                                        principal=principal)
+                    # Detach certificate from thing
+                    self._iot_client.detach_thing_principal(thingName=thing_name,
+                                                            principal=principal)
 
-                # Update certificate to INACTIVE
-                self._iot_client.update_certificate(certificateId=cert_id,
-                                                    newStatus='INACTIVE')
+                    # Update certificate to INACTIVE
+                    self._iot_client.update_certificate(certificateId=cert_id,
+                                                        newStatus='INACTIVE')
 
-                # Delete the certificate
-                self._iot_client.delete_certificate(certificateId=cert_id,
-                                                    forceDelete=True)
+                    # Delete the certificate
+                    self._iot_client.delete_certificate(certificateId=cert_id,
+                                                        forceDelete=True)
+                except Exception as e:
+                    print(f"Error cleaning up cert {principal} for thing '{thing_name}': {e}")
+                sleep(TEARDOWN_CALL_DELAY)
 
             # Finally, delete the thing
-            self._iot_client.delete_thing(thingName=thing_name)
+            _retry_on_throttle(
+                lambda: self._iot_client.delete_thing(thingName=thing_name))
 
             print(
                 f"Successfully deleted thing '{thing_name}' and its associated certificates"
@@ -268,15 +318,27 @@ class IoTUtils():
 
     def clean_up(self):
         print("\nRunning IoT clean up...")
-        try:
-
-            for thing_group in self._thing_groups:
+        # Isolate per-resource so the first failure doesn't skip the rest.
+        for thing_group in self._thing_groups:
+            try:
                 self.remove_thing_from_thing_group(self._thing_name,
                                                    thing_group)
+            except Exception as e:
+                print(f"Error removing thing from group {thing_group}: {e}")
+            try:
                 self.delete_thing_group(thing_group)
+            except Exception as e:
+                print(f"Error deleting thing group {thing_group}: {e}")
+            sleep(TEARDOWN_CALL_DELAY)
 
-            # Delete the core device
+        # Delete the core device
+        try:
             self.delete_core_device()
+        except Exception as e:
+            print(f"Error deleting core device: {e}")
+        sleep(TEARDOWN_CALL_DELAY)
+
+        try:
             self.delete_thing(self._thing_name)
 
             # Delete provisioned role and alias if created
@@ -305,15 +367,15 @@ class IoTUtils():
                 except Exception as e:
                     print(f"Could not delete role: {e}")
 
-        print("IoT clean-up completed.\n")
-                # Delete the JSON file
-            try:
-                subprocess.run(['rm', '-rf', JSON_FILE], check=True)
-            except Exception as e:
-                print(f"Error when removing the JSON file, {str(e)}")
-
+        print("IoT clean-up completed.\n")   
         except Exception as e:
-            print(f"Error during cleanup: {str(e)}")
+            print(f"Error deleting thing {self._thing_name}: {e}")
+
+        # Delete the JSON file
+        try:
+            subprocess.run(['rm', '-rf', JSON_FILE], check=True)
+        except Exception as e:
+            print(f"Error when removing the JSON file, {str(e)}")
 
     # ===============================================
     # HELPER FUNCTIONS

--- a/src/IoTUtils.py
+++ b/src/IoTUtils.py
@@ -21,6 +21,8 @@ class IoTUtils():
         self._thing_groups = []
         self._provisioned_role_name = None
         self._provisioned_role_alias = None
+        self._provisioned_role_name = None
+        self._provisioned_role_alias = None
 
     @property
     def thing_name(self):
@@ -34,6 +36,10 @@ class IoTUtils():
             endpointType="iot:CredentialProvider")["endpointAddress"]
         return {"iotDataEndpoint": data_ep, "iotCredEndpoint": cred_ep}
 
+    def provision_for_endpoint_switch(self,
+                                      cert_pem: str,
+                                      role_alias_name: str,
+                                      role_name: str = "ggl-uat-role"):
     def provision_for_endpoint_switch(self,
                                       cert_pem: str,
                                       role_alias_name: str,
@@ -97,6 +103,8 @@ class IoTUtils():
             return None
 
         # set up role and role alias
+        role_arn, _ = self._create_iot_role()
+        role_alias_arn, _ = self._create_role_alias(role_arn)
         role_arn, _ = self._create_iot_role()
         role_alias_arn, _ = self._create_role_alias(role_arn)
         self._attach_thing_policy(role_alias_arn, cert_arn)
@@ -297,9 +305,8 @@ class IoTUtils():
                 except Exception as e:
                     print(f"Could not delete role: {e}")
 
-            print("IoT clean-up completed.\n")
-
-            # Delete the JSON file
+        print("IoT clean-up completed.\n")
+                # Delete the JSON file
             try:
                 subprocess.run(['rm', '-rf', JSON_FILE], check=True)
             except Exception as e:
@@ -311,6 +318,9 @@ class IoTUtils():
     # ===============================================
     # HELPER FUNCTIONS
     # ===============================================
+    def _create_iot_role(self,
+                         role_name: str = "ggl-uat-role"
+                         ) -> tuple[str | None, bool]:
     def _create_iot_role(self,
                          role_name: str = "ggl-uat-role"
                          ) -> tuple[str | None, bool]:
@@ -336,6 +346,8 @@ class IoTUtils():
                     "logs:CreateLogGroup", "logs:CreateLogStream",
                     "logs:PutLogEvents", "logs:DescribeLogStreams",
                     "iot:DescribeEndpoint", "s3:*"
+                    "logs:PutLogEvents", "logs:DescribeLogStreams",
+                    "iot:DescribeEndpoint", "s3:*"
                 ],
                 "Resource":
                 "*"
@@ -343,10 +355,12 @@ class IoTUtils():
         }
 
         policy_name = f"{role_name}-token-exchange-policy"
+        policy_name = f"{role_name}-token-exchange-policy"
 
         try:
             role_response = self._iam_client.get_role(RoleName=role_name)
             print(f"Role '{role_name}' already exists.")
+            return (role_response['Role']['Arn'], False)
             return (role_response['Role']['Arn'], False)
 
         except self._iam_client.exceptions.NoSuchEntityException:
@@ -362,11 +376,17 @@ class IoTUtils():
                 RoleName=role_name, PolicyArn=policy_response['Policy']['Arn'])
 
             return (role_response['Role']['Arn'], True)
+            return (role_response['Role']['Arn'], True)
 
         except Exception as e:
             print(f"Error creating role: {str(e)}")
             return (None, False)
+            return (None, False)
 
+    def _create_role_alias(self,
+                           role_arn: str,
+                           role_alias_name: str = "ggl-uat-role-alias"
+                           ) -> tuple[str | None, bool]:
     def _create_role_alias(self,
                            role_arn: str,
                            role_alias_name: str = "ggl-uat-role-alias"
@@ -377,6 +397,7 @@ class IoTUtils():
                 roleAlias=role_alias_name)
             print(f"Role alias '{role_alias_name}' already exists.")
             return (response['roleAliasDescription']['roleAliasArn'], False)
+            return (response['roleAliasDescription']['roleAliasArn'], False)
 
         except self._iot_client.exceptions.ResourceNotFoundException:
             response = self._iot_client.create_role_alias(
@@ -385,9 +406,11 @@ class IoTUtils():
                 credentialDurationSeconds=3600)
 
             return (response['roleAliasArn'], True)
+            return (response['roleAliasArn'], True)
 
         except Exception as e:
             print(f"Error creating role alias: {str(e)}")
+            return (None, False)
             return (None, False)
 
     def _attach_thing_policy(self,

--- a/src/IoTUtils.py
+++ b/src/IoTUtils.py
@@ -16,12 +16,16 @@ JSON_FILE = "/tmp/aws-greengrass-testing-workspace/iot_setup_data.json"
 # IoT Core / GGv2 API throttling under parallel UAT load.
 THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
 
-TEARDOWN_CALL_DELAY = 0.5  # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
+TEARDOWN_CALL_DELAY = 0.5    # seconds between destructive teardown calls to ease IoT Jobs DELETION_IN_PROGRESS limits
 
 # Retryable throttling error codes from AWS APIs.
 _THROTTLE_CODES = frozenset({
-    "ThrottlingException", "Throttling", "ThrottledException",
-    "TooManyRequestsException", "RequestLimitExceeded", "LimitExceededException",
+    "ThrottlingException",
+    "Throttling",
+    "ThrottledException",
+    "TooManyRequestsException",
+    "RequestLimitExceeded",
+    "LimitExceededException",
 })
 
 
@@ -36,15 +40,19 @@ def _retry_on_throttle(func, *, attempts=3, base_delay=1.0, cap=10.0):
         except ClientError as e:
             code = e.response["Error"].get("Code", "")
             if code not in _THROTTLE_CODES or attempt == attempts - 1:
-                raise  # non-retryable or final attempt — propagate
-            delay = random.uniform(0, min(base_delay * 2 ** attempt, cap))
-            print(f"  Throttled ({code}), retry {attempt + 1}/{attempts} after {delay:.1f}s")
+                raise    # non-retryable or final attempt — propagate
+            delay = random.uniform(0, min(base_delay * 2**attempt, cap))
+            print(
+                f"  Throttled ({code}), retry {attempt + 1}/{attempts} after {delay:.1f}s"
+            )
             sleep(delay)
         except (BotoCoreError, botocore.exceptions.ConnectionError):
             if attempt == attempts - 1:
                 raise
-            delay = random.uniform(0, min(base_delay * 2 ** attempt, cap))
-            print(f"  Transient error, retry {attempt + 1}/{attempts} after {delay:.1f}s")
+            delay = random.uniform(0, min(base_delay * 2**attempt, cap))
+            print(
+                f"  Transient error, retry {attempt + 1}/{attempts} after {delay:.1f}s"
+            )
             sleep(delay)
 
 
@@ -53,9 +61,15 @@ class IoTUtils():
     def __init__(self, region: str, thing_name: str = None):
         self._region = region
         self._thing_name = thing_name
-        self._iot_client = client("iot", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
-        self._iam_client = client("iam", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
-        self._gg_client = client("greengrassv2", region_name=self._region, config=THROTTLE_RETRY_CONFIG)
+        self._iot_client = client("iot",
+                                  region_name=self._region,
+                                  config=THROTTLE_RETRY_CONFIG)
+        self._iam_client = client("iam",
+                                  region_name=self._region,
+                                  config=THROTTLE_RETRY_CONFIG)
+        self._gg_client = client("greengrassv2",
+                                 region_name=self._region,
+                                 config=THROTTLE_RETRY_CONFIG)
         self._thing_groups = []
         self._provisioned_role_name = None
         self._provisioned_role_alias = None
@@ -226,7 +240,9 @@ class IoTUtils():
                         self._gg_client.cancel_deployment(
                             deploymentId=deployment['deploymentId'])
                     except Exception as e:
-                        print(f"Failed to cancel deployment {deployment['deploymentId']}: {e}")
+                        print(
+                            f"Failed to cancel deployment {deployment['deploymentId']}: {e}"
+                        )
                     sleep(TEARDOWN_CALL_DELAY)
                 print(f"Cancelled all deployments")
 
@@ -236,9 +252,11 @@ class IoTUtils():
 
         # Delete the core device
         try:
-            _retry_on_throttle(
-                lambda: self._gg_client.delete_core_device(
-                    coreDeviceThingName=self._thing_name))
+            _retry_on_throttle(lambda: self._gg_client.delete_core_device(
+                coreDeviceThingName=self._thing_name),
+                               attempts=5,
+                               base_delay=2.0,
+                               cap=30.0)
             print(f"Deleted Greengrass core device '{self._thing_name}'")
         except Exception as e:
             print(f"Failed to delete Greengrass core device: {str(e)}")
@@ -267,8 +285,8 @@ class IoTUtils():
                             policyName=policy['policyName'], target=principal)
 
                     # Detach certificate from thing
-                    self._iot_client.detach_thing_principal(thingName=thing_name,
-                                                            principal=principal)
+                    self._iot_client.detach_thing_principal(
+                        thingName=thing_name, principal=principal)
 
                     # Update certificate to INACTIVE
                     self._iot_client.update_certificate(certificateId=cert_id,
@@ -278,12 +296,17 @@ class IoTUtils():
                     self._iot_client.delete_certificate(certificateId=cert_id,
                                                         forceDelete=True)
                 except Exception as e:
-                    print(f"Error cleaning up cert {principal} for thing '{thing_name}': {e}")
+                    print(
+                        f"Error cleaning up cert {principal} for thing '{thing_name}': {e}"
+                    )
                 sleep(TEARDOWN_CALL_DELAY)
 
             # Finally, delete the thing
             _retry_on_throttle(
-                lambda: self._iot_client.delete_thing(thingName=thing_name))
+                lambda: self._iot_client.delete_thing(thingName=thing_name),
+                attempts=5,
+                base_delay=2.0,
+                cap=30.0)
 
             print(
                 f"Successfully deleted thing '{thing_name}' and its associated certificates"

--- a/src/aws-greengrass-testing-system-log-forwarder.py
+++ b/src/aws-greengrass-testing-system-log-forwarder.py
@@ -8,7 +8,11 @@ from src.SystemInterface import SystemInterface
 
 import time
 import boto3
+from botocore.config import Config
 import src.GGLSetup as ggl_setup
+
+# Adaptive retry config: absorb CloudWatch Logs API throttling under parallel UAT load.
+THROTTLE_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "adaptive"})
 
 
 @fixture(scope="function")
@@ -55,7 +59,7 @@ def system_interface() -> Generator[SystemInterface, None, None]:
 @fixture(scope="function")
 def cloudwatch_cleanup(request) -> Generator[None, None, None]:
     region = request.config.getoption("--region")
-    logs_client = boto3.client('logs', region_name=region)
+    logs_client = boto3.client('logs', region_name=region, config=THROTTLE_RETRY_CONFIG)
 
     # Store cleanup info with unique log group per test
     import time
@@ -243,7 +247,7 @@ def test_SLF_1_T2(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Check CloudWatch logs for system logs
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region)
+    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
     log_group_name = cloudwatch_cleanup['log_group_name']
     log_stream_name = iot_obj.thing_name
 
@@ -331,7 +335,7 @@ def test_SLF_1_T3(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Verify the custom log group was created by SystemLogForwarder
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region)
+    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
 
     try:
         response = logs_client.describe_log_groups(
@@ -414,7 +418,7 @@ def test_SLF_1_T4(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Verify the custom log stream was created by SystemLogForwarder
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region)
+    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
 
     try:
         response = logs_client.describe_log_streams(

--- a/src/aws-greengrass-testing-system-log-forwarder.py
+++ b/src/aws-greengrass-testing-system-log-forwarder.py
@@ -59,7 +59,9 @@ def system_interface() -> Generator[SystemInterface, None, None]:
 @fixture(scope="function")
 def cloudwatch_cleanup(request) -> Generator[None, None, None]:
     region = request.config.getoption("--region")
-    logs_client = boto3.client('logs', region_name=region, config=THROTTLE_RETRY_CONFIG)
+    logs_client = boto3.client('logs',
+                               region_name=region,
+                               config=THROTTLE_RETRY_CONFIG)
 
     # Store cleanup info with unique log group per test
     import time
@@ -247,7 +249,9 @@ def test_SLF_1_T2(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Check CloudWatch logs for system logs
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
+    logs_client = boto3.client('logs',
+                               region_name=gg_util_obj._region,
+                               config=THROTTLE_RETRY_CONFIG)
     log_group_name = cloudwatch_cleanup['log_group_name']
     log_stream_name = iot_obj.thing_name
 
@@ -335,7 +339,9 @@ def test_SLF_1_T3(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Verify the custom log group was created by SystemLogForwarder
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
+    logs_client = boto3.client('logs',
+                               region_name=gg_util_obj._region,
+                               config=THROTTLE_RETRY_CONFIG)
 
     try:
         response = logs_client.describe_log_groups(
@@ -418,7 +424,9 @@ def test_SLF_1_T4(iot_obj: IoTUtils, cloudwatch_cleanup,
     print(f"Waiting for logs to appear in CloudWatch...")
 
     # Verify the custom log stream was created by SystemLogForwarder
-    logs_client = boto3.client('logs', region_name=gg_util_obj._region, config=THROTTLE_RETRY_CONFIG)
+    logs_client = boto3.client('logs',
+                               region_name=gg_util_obj._region,
+                               config=THROTTLE_RETRY_CONFIG)
 
     try:
         response = logs_client.describe_log_streams(


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-lite/issues/1133

**Description of changes:**

- Add adaptive retry config (`max_attempts=10, mode="adaptive"`) to all boto3 clients (IoT, GreengrassV2, S3, CloudWatch Logs).
- Replace fixed `sleep`s in the deployment / IoT job / core-device status poll loops with exponential backoff + jitter, and fail after a bounded number of consecutive API errors instead of silently timing out.
- Stop swallowing `ClientError`s: only `ResourceNotFoundException` is treated as "not found" (returns `None`); every other error — including `ThrottlingException` — is re-raised so the test fails loudly instead of reporting PASSED.
- Make teardown resilient and correctly ordered:
  - per-resource `try/except` isolation so one failed delete no longer skips the rest of cleanup;
  - delete the Greengrass **core device before** the IoT thing;
  - detach/deactivate/delete certificates per-principal;
  - small inter-call delay between destructive calls.
- Add a `_retry_on_throttle` helper (full-jitter backoff) and wrap the throttle-prone teardown calls (`cancel_deployment`, `delete_deployment`, `delete_core_device`, `delete_thing`), with an extended retry budget on the terminal deletes so they can survive the IoT Jobs `DELETION_IN_PROGRESS` slot-drain window.


By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.