### PR TITLE
Add endpoint switch TES cascade integration test

### DIFF
--- a/components/TesCredentialVerifier/1.0.0/artifacts/tes_credential_verifier.py
+++ b/components/TesCredentialVerifier/1.0.0/artifacts/tes_credential_verifier.py
@@ -1,0 +1,30 @@
+"""TES Credential Verifier — loops calling sts:GetCallerIdentity and
+iot:DescribeEndpoint, printing results for UAT journalctl assertions."""
+
+import time
+import boto3
+
+
+def main():
+    while True:
+        try:
+            sts = boto3.client("sts")
+            identity = sts.get_caller_identity()
+            arn = identity["Arn"]
+            print(f"TES_ROLE_ARN={arn}", flush=True)
+        except Exception as e:
+            print(f"TES_ROLE_ARN=ERROR: {e}", flush=True)
+
+        try:
+            iot = boto3.client("iot")
+            resp = iot.describe_endpoint(endpointType="iot:Data-ATS")
+            endpoint = resp["endpointAddress"]
+            print(f"IOT_ENDPOINT={endpoint}", flush=True)
+        except Exception as e:
+            print(f"IOT_ENDPOINT=ERROR: {e}", flush=True)
+
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/TesCredentialVerifier/1.0.0/recipe/TesCredentialVerifier-1.0.0.yaml
+++ b/components/TesCredentialVerifier/1.0.0/recipe/TesCredentialVerifier-1.0.0.yaml
@@ -1,0 +1,22 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: TesCredentialVerifier
+ComponentVersion: "1.0.0"
+ComponentDescription: >-
+  Verifies TES credentials by calling sts:GetCallerIdentity and
+  iot:DescribeEndpoint in a loop. Used by UAT to confirm credential cascade
+  after endpoint switch.
+ComponentPublisher: Me
+ComponentDependencies:
+  aws.greengrass.TokenExchangeService:
+    VersionRequirement: ">=2.0.0"
+    DependencyType: "HARD"
+Manifests:
+  - Platform:
+      os: "linux"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        python3 -u {artifacts:path}/tes_credential_verifier.py
+    Artifacts:
+      - URI: "s3://$bucketName$/$testArtifactsDirectory$/$randomId$/tes_credential_verifier.py"

--- a/src/IoTUtils.py
+++ b/src/IoTUtils.py
@@ -19,6 +19,8 @@ class IoTUtils():
         self._iam_client = client("iam", region_name=self._region)
         self._gg_client = client("greengrassv2", region_name=self._region)
         self._thing_groups = []
+        self._provisioned_role_name = None
+        self._provisioned_role_alias = None
 
     @property
     def thing_name(self):
@@ -32,8 +34,10 @@ class IoTUtils():
             endpointType="iot:CredentialProvider")["endpointAddress"]
         return {"iotDataEndpoint": data_ep, "iotCredEndpoint": cred_ep}
 
-    def provision_for_endpoint_switch(self, cert_pem: str,
-                                      role_alias_name: str):
+    def provision_for_endpoint_switch(self,
+                                      cert_pem: str,
+                                      role_alias_name: str,
+                                      role_name: str = "ggl-uat-role"):
         """Provision IoT resources for an existing device in this
         region. Registers the certificate PEM (without CA) and
         creates thing, policy, role, and role alias."""
@@ -43,8 +47,13 @@ class IoTUtils():
         cert_arn = resp['certificateArn']
         self._iot_client.attach_thing_principal(thingName=self._thing_name,
                                                 principal=cert_arn)
-        role_arn = self._create_iot_role()
-        role_alias_arn = self._create_role_alias(role_arn, role_alias_name)
+        role_arn, role_created = self._create_iot_role(role_name=role_name)
+        role_alias_arn, alias_created = self._create_role_alias(
+            role_arn, role_alias_name)
+        if role_created:
+            self._provisioned_role_name = role_name
+        if alias_created:
+            self._provisioned_role_alias = role_alias_name
         self._attach_thing_policy(role_alias_arn, cert_arn,
                                   "ggl-uat-thing-policy-dest")
         print(f"Provisioned thing '{self._thing_name}' in {self._region}")
@@ -88,8 +97,8 @@ class IoTUtils():
             return None
 
         # set up role and role alias
-        role_arn = self._create_iot_role()
-        role_alias_arn = self._create_role_alias(role_arn)
+        role_arn, _ = self._create_iot_role()
+        role_alias_arn, _ = self._create_role_alias(role_arn)
         self._attach_thing_policy(role_alias_arn, cert_arn)
 
         print(f"Successfully created a thing: {thing_name}")
@@ -261,6 +270,33 @@ class IoTUtils():
             # Delete the core device
             self.delete_core_device()
             self.delete_thing(self._thing_name)
+
+            # Delete provisioned role and alias if created
+            if self._provisioned_role_alias:
+                try:
+                    self._iot_client.delete_role_alias(
+                        roleAlias=self._provisioned_role_alias)
+                    print(
+                        f"Deleted role alias '{self._provisioned_role_alias}'")
+                except Exception as e:
+                    print(f"Could not delete role alias: {e}")
+            if self._provisioned_role_name:
+                try:
+                    attached = self._iam_client.list_attached_role_policies(
+                        RoleName=self._provisioned_role_name
+                    )['AttachedPolicies']
+                    for policy in attached:
+                        self._iam_client.detach_role_policy(
+                            RoleName=self._provisioned_role_name,
+                            PolicyArn=policy['PolicyArn'])
+                        self._iam_client.delete_policy(
+                            PolicyArn=policy['PolicyArn'])
+                    self._iam_client.delete_role(
+                        RoleName=self._provisioned_role_name)
+                    print(f"Deleted role '{self._provisioned_role_name}'")
+                except Exception as e:
+                    print(f"Could not delete role: {e}")
+
             print("IoT clean-up completed.\n")
 
             # Delete the JSON file
@@ -275,7 +311,9 @@ class IoTUtils():
     # ===============================================
     # HELPER FUNCTIONS
     # ===============================================
-    def _create_iot_role(self) -> str | None:
+    def _create_iot_role(self,
+                         role_name: str = "ggl-uat-role"
+                         ) -> tuple[str | None, bool]:
         trust_policy = {
             "Version":
             "2012-10-17",
@@ -296,20 +334,20 @@ class IoTUtils():
                 "Allow",
                 "Action": [
                     "logs:CreateLogGroup", "logs:CreateLogStream",
-                    "logs:PutLogEvents", "logs:DescribeLogStreams", "s3:*"
+                    "logs:PutLogEvents", "logs:DescribeLogStreams",
+                    "iot:DescribeEndpoint", "s3:*"
                 ],
                 "Resource":
                 "*"
             }]
         }
 
-        role_name = "ggl-uat-role"
-        policy_name = "ggl-uat-role-token-exchange-policy"
+        policy_name = f"{role_name}-token-exchange-policy"
 
         try:
             role_response = self._iam_client.get_role(RoleName=role_name)
             print(f"Role '{role_name}' already exists.")
-            return role_response['Role']['Arn']
+            return (role_response['Role']['Arn'], False)
 
         except self._iam_client.exceptions.NoSuchEntityException:
             role_response = self._iam_client.create_role(
@@ -323,22 +361,22 @@ class IoTUtils():
             self._iam_client.attach_role_policy(
                 RoleName=role_name, PolicyArn=policy_response['Policy']['Arn'])
 
-            return role_response['Role']['Arn']
+            return (role_response['Role']['Arn'], True)
 
         except Exception as e:
             print(f"Error creating role: {str(e)}")
-            return None
+            return (None, False)
 
-    def _create_role_alias(
-            self,
-            role_arn: str,
-            role_alias_name: str = "ggl-uat-role-alias") -> str | None:
+    def _create_role_alias(self,
+                           role_arn: str,
+                           role_alias_name: str = "ggl-uat-role-alias"
+                           ) -> tuple[str | None, bool]:
 
         try:
             response = self._iot_client.describe_role_alias(
                 roleAlias=role_alias_name)
             print(f"Role alias '{role_alias_name}' already exists.")
-            return response['roleAliasDescription']['roleAliasArn']
+            return (response['roleAliasDescription']['roleAliasArn'], False)
 
         except self._iot_client.exceptions.ResourceNotFoundException:
             response = self._iot_client.create_role_alias(
@@ -346,11 +384,11 @@ class IoTUtils():
                 roleArn=role_arn,
                 credentialDurationSeconds=3600)
 
-            return response['roleAliasArn']
+            return (response['roleAliasArn'], True)
 
         except Exception as e:
             print(f"Error creating role alias: {str(e)}")
-            return None
+            return (None, False)
 
     def _attach_thing_policy(self,
                              role_alias_arn: str,

--- a/src/aws-greengrass-testing-deployment.py
+++ b/src/aws-greengrass-testing-deployment.py
@@ -1634,6 +1634,95 @@ def test_Deployment_20_T2(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
         dest_iot_obj.clean_up()
 
 
+# Scenario: Deployment-20-T3: Endpoint switch TES cascade.
+# Deploys TesCredentialVerifier (HARD dep on TES), verifies it prints
+# source credentials, performs endpoint switch, and verifies the
+# component prints destination credentials after the cascade restart.
+def test_Deployment_20_T3(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                          system_interface: SystemInterface):
+    thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    thing_group_name = iot_obj.generate_thing_group_name(id)
+    assert iot_obj.add_thing_to_thing_group(thing_name,
+                                            thing_group_name) is True
+
+    source_region = gg_util_obj.aws_region
+    dest_region = _get_destination_region(source_region)
+
+    # Read the device certificate PEM from the setup data file
+    with open(JSON_FILE, 'r') as f:
+        setup_data = json.load(f)
+    cert_pem = setup_data['DEVICE_CERT']
+
+    # Provision IoT resources in the destination region with distinct role
+    dest_role_alias = "ggl-uat-role-alias-dest"
+    dest_iot_obj = IoTUtils(dest_region, thing_name=thing_name)
+    try:
+        dest_iot_obj.provision_for_endpoint_switch(
+            cert_pem,
+            role_alias_name=dest_role_alias,
+            role_name="ggl-uat-role-dest")
+
+        # Deploy TesCredentialVerifier alongside NucleusLite in source
+        thing_group_arn = gg_util_obj.get_thing_group_arn(thing_group_name)
+        verifier_info = gg_util_obj.upload_component_with_versions(
+            "TesCredentialVerifier", ["1.0.0"])
+        sleep_with_log(5, "waiting for component to be DEPLOYABLE")
+
+        nucleus_version = gg_util_obj.create_nucleus_lite_component(thing_name)
+        sleep_with_log(5, "waiting for NucleusLite component")
+
+        nucleus_component = ComponentDeploymentInfo(
+            name="aws.greengrass.NucleusLite",
+            versions=[nucleus_version],
+            merge_config=None,
+        )
+        result = gg_util_obj.create_deployment(
+            thingArn=thing_group_arn,
+            component_list=[nucleus_component, verifier_info],
+            deployment_name="TesCredentialVerifier_InitialDeploy",
+        )
+        deployment_id = result["deploymentId"]
+        assert deployment_id is not None
+        assert (gg_util_obj.wait_for_deployment_till_timeout(
+            180, deployment_id) == "SUCCEEDED")
+
+        # Verify component prints source credentials
+        service_name = f"ggl.{verifier_info.name}.service"
+        assert (system_interface.monitor_journalctl_for_message(service_name,
+                                                                "ggl-uat-role/",
+                                                                timeout=60)
+                is True)
+        assert (system_interface.monitor_journalctl_for_message(
+            service_name, f".iot.{source_region}.", timeout=30) is True)
+
+        # Perform endpoint switch deployment
+        dest_endpoints = dest_iot_obj.get_iot_endpoints()
+        deployment_id = _create_endpoint_switch_deployment(
+            source_gg_util_obj=gg_util_obj,
+            thing_group_arn=thing_group_arn,
+            thing_name=thing_name,
+            merge_config={
+                "iotDataEndpoint": dest_endpoints["iotDataEndpoint"],
+                "iotCredEndpoint": dest_endpoints["iotCredEndpoint"],
+                "iotRoleAlias": dest_role_alias,
+                "awsRegion": dest_region,
+            },
+            deployment_name="EndpointSwitch_TesCascade",
+        )
+        assert (gg_util_obj.wait_for_iot_job_status(180, deployment_id,
+                                                    thing_name) == "SUCCEEDED")
+
+        # Verify component prints destination credentials after cascade
+        assert (system_interface.monitor_journalctl_for_message(
+            service_name, "ggl-uat-role-dest/", timeout=60) is True)
+        assert (system_interface.monitor_journalctl_for_message(
+            service_name, f".iot.{dest_region}.", timeout=30) is True)
+    finally:
+        sleep_with_log(5)
+        dest_iot_obj.clean_up()
+
+
 # Scenario: Deployment-21-T1: When a configuration update is deployed to a component,
 # the component is redeployed; its lifecycle steps are re-run as part of the deployment.
 def test_Deployment_21_T1(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,


### PR DESCRIPTION
## Summary

Add `test_Deployment_20_T3` that verifies deployed components get fresh credentials from the destination account after an IoT endpoint switch. This proves the tesd restart + BindsTo cascade mechanism works end-to-end.

## Changes

1. **TesCredentialVerifier component** (`components/TesCredentialVerifier/1.0.0/`)
   - Recipe with HARD dependency on `aws.greengrass.TokenExchangeService`
   - Python artifact that loops calling `sts:GetCallerIdentity` and `iot:DescribeEndpoint`, printing role ARN and IoT endpoint to stdout

2. **IoTUtils** (`src/IoTUtils.py`)
   - Parameterize `_create_iot_role()` with optional `role_name` (default unchanged: `ggl-uat-role`)
   - Parameterize `provision_for_endpoint_switch()` with optional `role_name`
   - Add `iot:DescribeEndpoint` to token exchange policy

3. **Integration test** (`src/aws-greengrass-testing-deployment.py`)
   - New `test_Deployment_20_T3`: deploys TesCredentialVerifier, verifies source credentials, performs endpoint switch, verifies destination credentials appear after cascade restart

## Testing

Ran `test_Deployment_20_T3` against a Greengrass Lite device built from latest `main` (includes tesd self-restart on config change).

**Results (expected):**
- ✅ TesCredentialVerifier deployed and printed source role ARN (`ggl-uat-role/`)
- ✅ Component printed source IoT endpoint (`.iot.us-east-1.`)
- ✅ Endpoint switch deployment reported `SUCCEEDED`
- ✅ tesd restarted (confirmed via journalctl: `"Configuration key ... changed, restarting tesd."`)
- ❌ Component did NOT print destination credentials — **expected failure**: `BindsTo` binding from tes-serverd to tesd is not yet implemented. Without it, tesd restart does not cascade to tes-serverd and components.

**This test will pass** once the tes-serverd systemd unit file includes `BindsTo=ggl.core.tesd.service` (Step 2 of the TES restart plan).

## Backward Compatibility

- `_create_iot_role()` and `provision_for_endpoint_switch()` default to `ggl-uat-role` — existing tests unchanged
- `iot:DescribeEndpoint` only applies to newly created roles (existing roles are reused as-is)
