### PR TITLE
Reconcile IoT role alias role_arn on each test run

### DIFF
--- a/src/IoTUtils.py
+++ b/src/IoTUtils.py
@@ -473,7 +473,17 @@ class IoTUtils():
         try:
             response = self._iot_client.describe_role_alias(
                 roleAlias=role_alias_name)
-            print(f"Role alias '{role_alias_name}' already exists.")
+            existing_arn = response['roleAliasDescription']['roleArn']
+            if existing_arn != role_arn:
+                # Reconcile: alias exists but points to a different role.
+                # Without this, a stale role alias from a previous test run
+                # silently overrides the intended role_arn.
+                print(f"Role alias '{role_alias_name}' points to "
+                      f"'{existing_arn}', updating to '{role_arn}'.")
+                self._iot_client.update_role_alias(roleAlias=role_alias_name,
+                                                   roleArn=role_arn)
+            else:
+                print(f"Role alias '{role_alias_name}' already exists.")
             return (response['roleAliasDescription']['roleAliasArn'], False)
 
         except self._iot_client.exceptions.ResourceNotFoundException:


### PR DESCRIPTION
## Description

 `ggl-uat-role-alias-dest` in `us-east-1` had been pointing to
`ggl-uat-role` (source) rather than `ggl-uat-role-dest` for months, causing
`test_Deployment_20_T3` to always receive source-role credentials after the
endpoint switch and thus fail the `ggl-uat-role-dest` assertion in journalctl
output.

Compare the existing `role_arn` to the requested `role_arn` and call
`iot:UpdateRoleAlias` to reconcile when they differ.

`GGL-UAT-GH-Role` has been granted `iot:UpdateRoleAlias` out of band.

Follows the same fix pattern as PR #312 (role policy reconcile).

*By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.*