### PR TITLE
Add Nucleus config forwarding integration test

### DIFF
--- a/components/aws.gg.uat.local.NucleusConfigForwardingTestService/1.0.0/recipe/aws.gg.uat.local.NucleusConfigForwardingTestService-1.0.0.yaml
+++ b/components/aws.gg.uat.local.NucleusConfigForwardingTestService/1.0.0/recipe/aws.gg.uat.local.NucleusConfigForwardingTestService-1.0.0.yaml
@@ -1,0 +1,21 @@
+---
+RecipeFormatVersion: 2020-01-25
+ComponentName: aws.gg.uat.local.NucleusConfigForwardingTestService
+ComponentDescription:
+  Verifies that GetConfiguration and SubscribeToConfigurationUpdate requests
+  targeting aws.greengrass.Nucleus are transparently forwarded to the
+  aws.greengrass.NucleusLite configuration tree on Greengrass Lite.
+ComponentPublisher: Me
+ComponentVersion: 1.0.0
+ComponentConfiguration:
+  DefaultConfiguration: {}
+Manifests:
+  - Platform:
+      os: linux
+      runtime: "*"
+    Lifecycle:
+      install:
+        "python3 -m venv .venv && . .venv/bin/activate && python3 -m pip install
+        --quiet --disable-pip-version-check awsiotsdk"
+      run: |-
+        .venv/bin/python -u {artifacts:path}/nucleus_config_forwarding.py

--- a/components/local_artifacts/aws.gg.uat.local.NucleusConfigForwardingTestService/1.0.0/nucleus_config_forwarding.py
+++ b/components/local_artifacts/aws.gg.uat.local.NucleusConfigForwardingTestService/1.0.0/nucleus_config_forwarding.py
@@ -1,0 +1,153 @@
+# aws-greengrass-testing
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Verifies Nucleus -> NucleusLite config forwarding over Greengrass IPC.
+
+On Greengrass Lite, nucleus configuration is stored under the component name
+``aws.greengrass.NucleusLite``. This component talks to the nucleus using the
+classic ``aws.greengrass.Nucleus`` name and confirms:
+
+1. GetConfiguration: a forwarded read returns the same value as a direct
+   NucleusLite read, and the response echoes the requested name.
+2. SubscribeToConfigurationUpdate: subscribing by the classic name is accepted
+   (forwarded), and update events are delivered relabeled to
+   ``aws.greengrass.Nucleus`` (the name the caller subscribed to), not the
+   underlying ``aws.greengrass.NucleusLite``.
+
+The component logs sentinel lines that the integration test asserts on. It
+subscribes to the whole nucleus configuration and then blocks until it receives
+an update event (driven by the test via a NucleusLite config merge) or times
+out.
+"""
+import threading
+import time
+from sys import stderr
+from traceback import print_exc
+
+from awsiot.greengrasscoreipc.clientv2 import GreengrassCoreIPCClientV2
+
+NUCLEUS = "aws.greengrass.Nucleus"
+NUCLEUS_LITE = "aws.greengrass.NucleusLite"
+# iotDataEndpoint is seeded under NucleusLite configuration by the test setup.
+KEY = "iotDataEndpoint"
+# Keep in sync with probe_key in test_Component_30_T0.
+PROBE_KEY = "uatForwardingProbe"
+# Max time to wait for the test to drive a config-update event.
+EVENT_WAIT_SECONDS = 420
+# How often sentinel lines are re-printed for late-attaching journal monitors.
+REPRINT_INTERVAL_SECONDS = 5
+# How long to keep re-printing sentinels after the update event arrives. This
+# does not affect test runtime (the test finishes once its journal assertions
+# match); it keeps the sentinel block near the journal tail so failures are
+# easy to diagnose from captured logs, including monitors run without `since`.
+POST_EVENT_LINGER_SECONDS = 120
+
+
+def read_value(ipc_client, component_name, key):
+    resp = ipc_client.get_configuration(component_name=component_name,
+                                        key_path=[key])
+    # For a non-map value, the response value is {key: value}.
+    value = resp.value.get(key) if resp.value is not None else None
+    return resp.component_name, value
+
+
+def main():
+    ipc_client = None
+    try:
+        ipc_client = GreengrassCoreIPCClientV2()
+
+        # The test harness monitors the journal with `journalctl -f`, which
+        # only replays a few recent lines. Sentinel lines are therefore
+        # re-printed periodically so a monitor attaching at any time sees them.
+        sentinel_lines = []
+        sentinel_lock = threading.Lock()
+
+        def emit(line):
+            with sentinel_lock:
+                sentinel_lines.append(line)
+            print(line)
+
+        def reprint_sentinels():
+            with sentinel_lock:
+                for line in sentinel_lines:
+                    print(line)
+
+        # --- GetConfiguration forwarding ---
+        fwd_name, fwd_val = read_value(ipc_client, NUCLEUS, KEY)
+        _, direct_val = read_value(ipc_client, NUCLEUS_LITE, KEY)
+
+        emit("Forwarded Nucleus %s: %s" % (KEY, fwd_val))
+        emit("Direct NucleusLite %s: %s" % (KEY, direct_val))
+        emit("Echoed componentName: %s" % fwd_name)
+        if fwd_name == NUCLEUS:
+            emit("NUCLEUS RESPONSE COMPONENT NAME MATCH")
+        else:
+            emit("NUCLEUS RESPONSE COMPONENT NAME MISMATCH")
+
+        if fwd_val is not None and fwd_val == direct_val:
+            emit("NUCLEUS FORWARDING MATCH")
+        else:
+            emit("NUCLEUS FORWARDING MISMATCH")
+
+        # --- SubscribeToConfigurationUpdate forwarding + relabel ---
+        got_event = threading.Event()
+
+        def on_event(event):
+            try:
+                update = event.configuration_update_event
+                event_key_path = list(
+                    update.key_path) if update.key_path else []
+                key_path = "/".join(event_key_path)
+                emit("CONFIG UPDATE EVENT componentName=%s keyPath=%s" %
+                     (update.component_name, key_path))
+                if event_key_path == [PROBE_KEY]:
+                    got_event.set()
+            except Exception as e:    # noqa: BLE001 - report and continue
+                print("Config update event handler error: %s" % e)
+
+        try:
+            # Empty key_path subscribes to the whole component configuration, so
+            # any sub-key write notifies us.
+            ipc_client.subscribe_to_configuration_update(
+                component_name=NUCLEUS,
+                key_path=[],
+                on_stream_event=on_event,
+            )
+            emit("NUCLEUS SUBSCRIBE OK")
+        except Exception as e:    # noqa: BLE001 - report and exit broken
+            print("NUCLEUS SUBSCRIBE FAILED: %s" % e)
+            # Exit non-zero so the component reports broken rather than
+            # appearing healthy; close() still runs via the finally below.
+            exit(1)
+
+        # Wait for the test to drive a NucleusLite config change (delivered to
+        # this aws.greengrass.Nucleus subscriber), re-printing sentinels so the
+        # test's journal monitors observe them regardless of attach time.
+        deadline = time.monotonic() + EVENT_WAIT_SECONDS
+        while time.monotonic() < deadline:
+            if got_event.wait(timeout=REPRINT_INTERVAL_SECONDS):
+                break
+            reprint_sentinels()
+
+        if not got_event.is_set():
+            print("NUCLEUS SUBSCRIBE EVENT TIMEOUT")
+
+        # Linger after the event so monitors that attach later still see the
+        # full sentinel block (including the update event line).
+        linger_deadline = time.monotonic() + POST_EVENT_LINGER_SECONDS
+        while time.monotonic() < linger_deadline:
+            time.sleep(REPRINT_INTERVAL_SECONDS)
+            reprint_sentinels()
+    except Exception:
+        print("Exception occurred", file=stderr)
+        print_exc()
+        exit(1)
+    finally:
+        # Always release the IPC connection, including on failure paths
+        # (exit() raises SystemExit, which still runs this).
+        if ipc_client is not None:
+            ipc_client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/SystemInterface.py
+++ b/src/SystemInterface.py
@@ -278,8 +278,11 @@ class SystemInterface:
             except:
                 pass
 
-    def monitor_journalctl_for_message(self, service_name: str, message: str,
-                                       timeout: int | float) -> bool:
+    def monitor_journalctl_for_message(self,
+                                       service_name: str,
+                                       message: str,
+                                       timeout: int | float,
+                                       since: float | None = None) -> bool:
         try:
             cmd = [
                 "sudo",
@@ -289,6 +292,10 @@ class SystemInterface:
                 "-f",    # Follow mode - shows new entries as they are added
                 "--no-pager",
             ]
+            if since is not None:
+                # Include every matching entry from this test run, rather than
+                # journalctl's default tail from an earlier service invocation.
+                cmd.extend(["--since", f"@{since}", "--no-tail"])
 
             # Run the command and stream output
             process = subprocess.Popen(

--- a/src/aws-greengrass-testing-component.py
+++ b/src/aws-greengrass-testing-component.py
@@ -2,7 +2,7 @@ from typing import Generator
 from GGTestUtils import sleep_with_log
 from pytest import fixture, mark
 from src.IoTUtils import IoTUtils
-from src.GGTestUtils import GGTestUtils
+from src.GGTestUtils import GGTestUtils, ComponentDeploymentInfo
 from src.SystemInterface import SystemInterface
 
 import time
@@ -383,6 +383,97 @@ def test_Component_29_T4(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
     # }
     # """
     # GG_LITE CLI doesn't support this yet.
+
+
+# As an operator, GetConfiguration and SubscribeToConfigurationUpdate requests
+# for aws.greengrass.Nucleus are transparently forwarded to
+# aws.greengrass.NucleusLite on Greengrass Lite, and subscribe events are
+# relabeled back to the requested aws.greengrass.Nucleus name.
+def test_Component_30_T0(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                         system_interface: SystemInterface):
+    component_name = "aws.gg.uat.local.NucleusConfigForwardingTestService"
+    service = "ggl." + component_name + ".service"
+    # Keep in sync with PROBE_KEY in the forwarding component artifact.
+    probe_key = "uatForwardingProbe"
+    journal_since = time.time()
+
+    # Pre-condition: the test setup (setup_greengrass_lite, run by the iot_obj
+    # fixture) seeds iotDataEndpoint under aws.greengrass.NucleusLite
+    # configuration, which the component reads back through the Nucleus alias.
+
+    # I install the forwarding test component version 1.0.0 from local store
+    component_artifacts_dir = "./components/local_artifacts/"
+    component_recipe_dir = (
+        "./components/aws.gg.uat.local.NucleusConfigForwardingTestService/"
+        "1.0.0/recipe/")
+    assert (gg_util_obj.create_local_deployment(component_artifacts_dir,
+                                                component_recipe_dir,
+                                                component_name + "=1.0.0"))
+
+    # A GetConfiguration read using the classic aws.greengrass.Nucleus name
+    # returns the same value as a direct aws.greengrass.NucleusLite read.
+    assert (system_interface.monitor_journalctl_for_message(
+        service, "NUCLEUS FORWARDING MATCH", timeout=120, since=journal_since)
+            is True)
+
+    # The response is transparent: it echoes the requested component name.
+    assert (system_interface.monitor_journalctl_for_message(
+        service,
+        "NUCLEUS RESPONSE COMPONENT NAME MATCH",
+        timeout=20,
+        since=journal_since) is True)
+
+    # Subscribing via the classic Nucleus name is accepted (forwarded), not
+    # rejected with ResourceNotFoundError.
+    assert (system_interface.monitor_journalctl_for_message(
+        service, "NUCLEUS SUBSCRIBE OK", timeout=20, since=journal_since)
+            is True)
+
+    # Drive a NucleusLite configuration change via a cloud deployment and verify
+    # the subscribed component receives the update relabeled to
+    # aws.greengrass.Nucleus (not the underlying aws.greengrass.NucleusLite). A
+    # harmless probe key is merged so no nucleus behavior (e.g. an endpoint
+    # switch) is triggered. Cleanup is automatic: the thing group is registered
+    # by IoTUtils (removed and deleted in its clean_up) and the deployment by
+    # GGTestUtils (cancelled and deleted in its clean_up).
+    random_id = iot_obj.generate_random_id()
+    thing_group_name = iot_obj.generate_thing_group_name(random_id)
+    assert iot_obj.add_thing_to_thing_group(iot_obj.thing_name,
+                                            thing_group_name) is True
+    thing_group_arn = gg_util_obj.get_thing_group_arn(thing_group_name)
+
+    version = gg_util_obj.create_nucleus_lite_component(iot_obj.thing_name)
+    sleep_with_log(5, "waiting for NucleusLite component to be DEPLOYABLE")
+
+    probe_component = ComponentDeploymentInfo(
+        name="aws.greengrass.NucleusLite",
+        versions=[version],
+        merge_config={probe_key: "uat-" + random_id},
+    )
+    deployment_id = gg_util_obj.create_deployment(
+        thingArn=thing_group_arn,
+        component_list=[probe_component],
+        deployment_name="NucleusConfigForwardingProbe",
+    )["deploymentId"]
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id) == "SUCCEEDED")
+
+    # The component subscribed via aws.greengrass.Nucleus must receive the
+    # config-update event relabeled to aws.greengrass.Nucleus.
+    assert (system_interface.monitor_journalctl_for_message(
+        service, "CONFIG UPDATE EVENT componentName=aws.greengrass.Nucleus "
+        f"keyPath={probe_key}",
+        timeout=120,
+        since=journal_since) is True)
+
+    # No event may expose the underlying storage component name. The window is
+    # 2x the component's 5s sentinel reprint interval so a late or duplicate
+    # mislabeled event would also be caught.
+    assert (system_interface.monitor_journalctl_for_message(
+        service,
+        "CONFIG UPDATE EVENT componentName=aws.greengrass.NucleusLite keyPath=",
+        timeout=10,
+        since=journal_since) is False)
 
 
 # As a component developer, I can use automatic cleanup to delete component files further than last two deployments


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Adds `test_Component_30_T0` covering the Nucleus config-forwarding feature in
aws-greengrass-lite (branch `dev/nucleusconfigforward`): `GetConfiguration`
and `SubscribeToConfigurationUpdate` requests naming `aws.greengrass.Nucleus`
are served from the `aws.greengrass.NucleusLite` configuration tree, with
responses and events retaining the requested name.

- New local component `aws.gg.uat.local.NucleusConfigForwardingTestService`
  makes live IPC calls (not recipe interpolation, so the ggipcd handlers are
  exercised): it reads `iotDataEndpoint` via both the `aws.greengrass.Nucleus`
  alias and the direct NucleusLite name, subscribes to the whole nucleus
  configuration via the alias, and logs sentinel lines the test asserts on.
- The test local-deploys the component, then drives a NucleusLite
  configuration change via a cloud deployment that merges a harmless probe
  key, and asserts the subscriber receives the update event relabeled to
  `aws.greengrass.Nucleus` with the probe keyPath — and that no event ever
  exposes the underlying `aws.greengrass.NucleusLite` name.
- `SystemInterface.monitor_journalctl_for_message` gains an optional `since`
  parameter (`journalctl --since @<epoch> --no-tail`) to scope matching to the
  current test run. Default behavior is unchanged for all existing tests.
- The component re-prints its sentinel lines periodically: the harness
  monitors logs with `journalctl -f`, which only replays a few recent lines,
  so one-shot prints raced monitor attach.

**Why is this change necessary:**

The forwarding alias lives in the ggipcd IPC handlers; existing config tests
use recipe interpolation, which never reaches those handlers. This test is the
end-to-end coverage for the feature, including the event-relabel transparency
that cannot be verified without driving a real config change into a live
subscription.

**How was this change tested:**

Run in a podman systemd container (`misc/buildtestcontainer`) against a real
IoT Core account, building aws-greengrass-lite from the feature branch:
`1 passed in 72.02s`. Verified sentinels: `NUCLEUS FORWARDING MATCH`,
`NUCLEUS RESPONSE COMPONENT NAME MATCH`, `NUCLEUS SUBSCRIBE OK`, and
`CONFIG UPDATE EVENT componentName=aws.greengrass.Nucleus
keyPath=uatForwardingProbe`, with zero NucleusLite-labeled events.

**Any additional information or context required to review the change:**

Companion runtime PR: aws-greengrass-lite branch `dev/nucleusconfigforward`.
The test requires that branch (or a release containing it) to pass; against
current mainline the forwarded read returns ResourceNotFoundError and the
test fails.

The probe key `uatForwardingProbe` is intentionally defined in both the
component artifact and the test driver (cross-referenced comments keep them
in sync); it is a harmless key merged into NucleusLite configuration so no
nucleus behavior (e.g. an endpoint switch) is triggered.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
