### PR TITLE
Install boto3 for TesCredentialVerifier component

### DIFF
--- a/components/TesCredentialVerifier/1.0.0/recipe/TesCredentialVerifier-1.0.0.yaml
+++ b/components/TesCredentialVerifier/1.0.0/recipe/TesCredentialVerifier-1.0.0.yaml
@@ -16,7 +16,10 @@ Manifests:
       os: "linux"
       runtime: "*"
     Lifecycle:
+      install:
+        "python3 -m venv .venv && . .venv/bin/activate && python3 -m pip install
+        boto3"
       run: |-
-        python3 -u {artifacts:path}/tes_credential_verifier.py
+        .venv/bin/python -u {artifacts:path}/tes_credential_verifier.py
     Artifacts:
       - URI: "s3://$bucketName$/$testArtifactsDirectory$/$randomId$/tes_credential_verifier.py"

--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -1,6 +1,7 @@
 armv7
 ASAN
 awsiotsdk
+boto
 cbor
 clientv
 coreutils


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Add an `install` lifecycle to the `TesCredentialVerifier` UAT component that
creates a virtualenv and installs `boto3`, and run the script with the venv
interpreter (mirroring the `HelloWorldPubSub` component).

**Scope:** one file, the `TesCredentialVerifier` recipe. This does not change
test logic, the deployment suite, any other component, or the Greengrass
runtime. It only makes this one component install the dependency it already
requires.

**Why is this change necessary:**

`test_Deployment_20_T3` deploys `TesCredentialVerifier`, whose script imports
`boto3` at module scope. The recipe ran it with the bare system interpreter and
had no dependency install step, so it only works when `boto3` happens to already
be present on the system Python. When it is not, the component fails at import
on every start:

```
ModuleNotFoundError: No module named 'boto3'
```

That exhausts the systemd restart limit, `gghealthd` marks the component broken
("Exceeded retry limit"), the deployment reports `coreDeviceExecutionStatus:
FAILED`, and the test fails asserting `FAILED == SUCCEEDED`.

**Why it passed in some runs and not others:**

Whether the component's bare `python3` can import `boto3` depends on where the
surrounding test harness installs its own dependencies, and that differs by
workflow:

- The **aws-greengrass-lite** UAT installs the harness (which depends on
  `boto3`) into the **system** Python, so the component inherits `boto3` and
  passes (e.g. lite run 29767593963, 2026-07-20: `1 passed`, full endpoint
  switch cascade).
- The **aws-greengrass-testing** UAT runs `run-tests.sh`, which installs the
  harness into an **isolated venv** (`/tmp/aws-greengrass-testing-workspace/venv`).
  The component's system `python3` then has no `boto3`, so it fails.

The component was relying on `boto3` leaking in from a system-wide harness
install. This PR removes that reliance: the component installs its own `boto3`
in its own venv, so it behaves the same regardless of how the harness is set up.

The test was added in #301, but its UAT job never ran on that PR (the per-PR
UAT workflow did not exist yet), so the missing install step was not caught
before merge.

**How was this change tested:**

- Reproduced the failure in a podman systemd container against
  aws-greengrass-lite mainline: `ModuleNotFoundError: No module named 'boto3'`
  -> component broken -> deployment `FAILED`, matching CI.
- With this fix the component starts and runs: it emitted `TES_ROLE_ARN` for
  both the source and destination roles (the credential cascade the test
  asserts). A clean end-to-end green on the testing-repo UAT is still pending;
  the local repro run hit a transient container DNS failure after the component
  came up. <!-- TODO: attach a clean 20_T3 green before marking ready -->

**Any additional information or context required to review the change:**

Unrelated to, but surfaced by, the Nucleus config forwarding PR (#316), whose
CI run exercised this pre-existing failure. Independent fix, branched from
`main`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
