### PR TITLE
Add UATs for variable-interpolated MQTT topic filters

### DIFF
--- a/components/HelloWorldMqtt/2.0.0/artifacts/hello_world_mqtt.py
+++ b/components/HelloWorldMqtt/2.0.0/artifacts/hello_world_mqtt.py
@@ -1,0 +1,65 @@
+from sys import argv, stderr
+from traceback import print_exc
+
+from awsiot.greengrasscoreipc.clientv2 import GreengrassCoreIPCClientV2
+from awsiot.greengrasscoreipc.model import IoTCoreMessage
+
+
+def subscribe_to_iot_core(ipc_client: GreengrassCoreIPCClientV2, topic_name):
+    return ipc_client.subscribe_to_iot_core(topic_name=topic_name,
+                                            on_stream_event=_on_stream_event,
+                                            on_stream_error=_on_stream_error,
+                                            on_stream_closed=_on_stream_closed)
+
+
+def _on_stream_event(event: IoTCoreMessage) -> None:
+    try:
+        topic = event.message.topic_name
+        message = str(event.message.payload, "utf-8")
+        print(f"Received new message on topic {topic}: {message}")
+    except Exception as e:
+        print("Exception occurred: " + str(e))
+        print_exc()
+
+
+def _on_stream_error(error: Exception) -> bool:
+    print("Received a stream error.", file=stderr)
+    print_exc()
+    return False    # Return True to close stream, False to keep stream open.
+
+
+def _on_stream_closed() -> None:
+    print("Subscribe to topic stream closed.")
+
+
+def publish_binary_message_to_iot_core(ipc_client: GreengrassCoreIPCClientV2,
+                                       topic, message):
+    return ipc_client.publish_to_iot_core(topic_name=topic, payload=message)
+
+
+def publish_message_N_times(ipc_client, topic, message, N=10):
+    for i in range(1, N + 1):
+        publish_binary_message_to_iot_core(ipc_client, topic, message)
+        print("Successfully published " + str(i) + " message(s)")
+
+
+def main():
+    args = argv[1:]
+    topic = args[0]
+    message = " ".join(args[1:])
+
+    try:
+        ipc_client = GreengrassCoreIPCClientV2()
+        # Subscribe to the topic before publishing
+        subscribe_to_iot_core(ipc_client, topic)
+        print(f"Successfully subscribed to {topic}")
+        # Publish a message for N times and exit
+        publish_message_N_times(ipc_client, topic, message)
+    except Exception:
+        print("Exception occurred", file=stderr)
+        print_exc()
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/HelloWorldMqtt/2.0.0/recipe/HelloWorldMqtt-2.0.0.yaml
+++ b/components/HelloWorldMqtt/2.0.0/recipe/HelloWorldMqtt-2.0.0.yaml
@@ -1,0 +1,36 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: "HelloWorldMqtt"
+ComponentVersion: "2.0.0"
+ComponentType: "aws.greengrass.generic"
+ComponentDescription:
+  "MQTT component that uses {iot:thingName} interpolated policy resource strings
+  for authorization."
+ComponentPublisher: "Me"
+ComponentConfiguration:
+  DefaultConfiguration:
+    Message: "Hello from IoT Core"
+    Topic: "test/topic"
+    accessControl:
+      aws.greengrass.ipc.mqttproxy:
+        HelloWorldMqtt:mqttproxy:1:
+          policyDescription:
+            "Allows access to publish and subscribe to a topic using
+            interpolated thingName"
+          operations:
+            - "aws.greengrass#SubscribeToIoTCore"
+            - "aws.greengrass#PublishToIoTCore"
+          resources: ["{iot:thingName}/test/topic"]
+Manifests:
+  - Platform:
+      os: "linux"
+      runtime: "*"
+    Lifecycle:
+      install: |-
+        python3 -m venv .venv
+        .venv/bin/python3 -m pip install awsiotsdk
+      run: |-
+        .venv/bin/python3 -u {artifacts:path}/hello_world_mqtt.py "{iot:thingName}/{configuration:/Topic}" "{configuration:/Message}"
+    Artifacts:
+      - Uri: "s3://$bucketName$/$testArtifactsDirectory$/$randomId$/hello_world_mqtt.py"
+Lifecycle: {}

--- a/src/aws-greengrass-testing-security.py
+++ b/src/aws-greengrass-testing-security.py
@@ -471,3 +471,93 @@ def test_Security_6_T22(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
         "ggl." + publisher_cloud_name[0] + ".service",
         "UnauthorizedError",
         timeout=20) is True)
+
+
+# Scenario: Security-6-T23
+# As a service owner, I want to use interpolated recipe variables like {iot:thingName}
+# in MQTT authorization policy resource strings. The authorization should resolve
+# the variable at runtime and allow publish/subscribe when the topic matches.
+def test_Security_6_T23(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                        system_interface: SystemInterface):
+    security_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    security_thing_group_name = iot_obj.generate_thing_group_name(id)
+    security_thing_group_result = iot_obj.add_thing_to_thing_group(
+        security_thing_name, security_thing_group_name)
+    assert security_thing_group_result is True
+
+    # Deploy HelloWorldMqtt 2.0.0. Its lifecycle builds the request topic from
+    # a directly interpolated thing name and the configured topic suffix, while
+    # its access control policy uses an interpolated resource.
+    mqtt_cloud_name = gg_util_obj.upload_component_with_versions(
+        "HelloWorldMqtt", ["2.0.0"])
+    if mqtt_cloud_name is None:
+        raise RuntimeError(
+            "Fatal error: HelloWorldMqtt 2.0.0 cannot be uploaded to cloud")
+
+    deployment_id = gg_util_obj.create_deployment(
+        thingArn=gg_util_obj.get_thing_group_arn(security_thing_group_name),
+        component_list=[mqtt_cloud_name],
+        deployment_name="InterpolatedMqttResourceDeploy")["deploymentId"]
+
+    assert (gg_util_obj.wait_for_deployment_till_timeout(
+        240, deployment_id) == "SUCCEEDED")
+
+    sleep_with_log(5)
+
+    # The lifecycle and policy independently interpolate {iot:thingName} to
+    # the same <thing-name>/test/topic resource, so authorization should succeed.
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl." + mqtt_cloud_name[0] + ".service",
+        "Successfully subscribed to",
+        timeout=60) is True)
+
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl." + mqtt_cloud_name[0] + ".service",
+        "Successfully published 1 message(s)",
+        timeout=60) is True)
+
+
+# Scenario: Security-6-T24
+# As a service owner, I want to ensure that when an interpolated MQTT policy
+# resource does NOT match the topic the component publishes to, authorization
+# is denied.
+def test_Security_6_T24(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                        system_interface: SystemInterface):
+    security_thing_name = iot_obj.thing_name
+    id = iot_obj.generate_random_id()
+    security_thing_group_name = iot_obj.generate_thing_group_name(id)
+    security_thing_group_result = iot_obj.add_thing_to_thing_group(
+        security_thing_name, security_thing_group_name)
+    assert security_thing_group_result is True
+
+    # Deploy HelloWorldMqtt 2.0.0 with the other/topic suffix, but override the
+    # policy resource to a different interpolated path. Authorization should
+    # compare <thing-name>/other/topic with <thing-name>/test/topic and deny it.
+    mqtt_cloud_name = gg_util_obj.upload_component_with_versions(
+        "HelloWorldMqtt", ["2.0.0"])
+    if mqtt_cloud_name is None:
+        raise RuntimeError(
+            "Fatal error: HelloWorldMqtt 2.0.0 cannot be uploaded to cloud")
+
+    mqtt_cloud_name = mqtt_cloud_name._replace(
+        merge_config={"Topic": "other/topic"})
+
+    deployment_id = gg_util_obj.create_deployment(
+        thingArn=gg_util_obj.get_thing_group_arn(security_thing_group_name),
+        component_list=[mqtt_cloud_name],
+        deployment_name="MismatchedInterpolatedMqttResourceDeploy"
+    )["deploymentId"]
+
+    # The deployment should fail because the concrete request topic does not
+    # match the interpolated policy resource.
+    deployment_result = gg_util_obj.wait_for_deployment_till_timeout(
+        180, deployment_id)
+    assert (deployment_result == "FAILED")
+
+    sleep_with_log(5)
+
+    # Verify that an authorization error was logged
+    assert (system_interface.monitor_journalctl_for_message(
+        "ggl." + mqtt_cloud_name[0] + ".service", "IPC error", timeout=30)
+            is True)


### PR DESCRIPTION
**Description of changes:**
Add a happy path and an auth failure test for interpolating `{iot:thingName}`
inside an MQTT topic filter allowed resource.

**Why  is this change necessary:**
Code coverage for 
aws-greengrass/aws-greengrass-lite#1153

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
