### PR TITLE
Fix service output during test failure

### DIFF
--- a/src/GGTestUtils.py
+++ b/src/GGTestUtils.py
@@ -632,8 +632,8 @@ class GGTestUtils:
             ]
             for svc in services:
                 log_output = subprocess.run([
-                    "/usr/bin/journalctl", "-u", svc, "--no-pager", "-n", "50",
-                    "--since", "5 minutes ago"
+                    "/usr/bin/journalctl", "-u", f"ggl.core.{svc}.service",
+                    "--no-pager", "-n", "50", "--since", "5 minutes ago"
                 ],
                                             capture_output=True,
                                             text=True,
@@ -641,7 +641,7 @@ class GGTestUtils:
                 if (log_output.stdout.strip()
                         and "-- No entries --" not in log_output.stdout):
                     print(f"\n--- {svc} logs ---")
-                    print(log_output.stdout[-1500:])
+                    print(log_output.stdout)
 
             error_log = subprocess.run([
                 "/usr/bin/journalctl", "--no-pager", "-p", "err", "--since",


### PR DESCRIPTION
The filter passed to journalctl used the incomplete systemd service names.

**Issue #, if available:**

**Description of changes:**
Fix unit filter passed to journalctl when debugging test output

**Why is this change necessary:**
Test failure has incomplete information

**How was this change tested:**
Manually calling GGTestUtils' _dump_device_logs method from inside a test.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
