### PR TITLE
Add Component_29_T5 for nonexistent configuration variables

### DIFF
--- a/components/SampleComponentWithMissingConfiguration/1.0.0/recipe/SampleComponentWithMissingConfiguration-1.0.0.yaml
+++ b/components/SampleComponentWithMissingConfiguration/1.0.0/recipe/SampleComponentWithMissingConfiguration-1.0.0.yaml
@@ -1,0 +1,23 @@
+---
+RecipeFormatVersion: "2020-01-25"
+ComponentName: SampleComponentWithMissingConfiguration
+ComponentVersion: "1.0.0"
+ComponentDescription:
+  Sample component whose lifecycle references both an existing and a nonexistent
+  configuration value
+ComponentPublisher: Amazon
+ComponentConfiguration:
+  DefaultConfiguration:
+    MyConfigKey: "MyConfigDefaultValue"
+Manifests:
+  - Platform:
+      os: "*"
+      runtime: "*"
+    Lifecycle:
+      run: |-
+        while true; do
+        echo present={configuration:/MyConfigKey}
+        echo missing={configuration:/NoSuchKey}
+        echo TAIL_REACHED
+        sleep 5
+        done

--- a/src/aws-greengrass-testing-component.py
+++ b/src/aws-greengrass-testing-component.py
@@ -385,6 +385,44 @@ def test_Component_29_T4(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
     # GG_LITE CLI doesn't support this yet.
 
 
+# As an operator, when I interpolate component default configurations by local
+# deployment, a recipe variable naming a configuration value that does not exist
+# is left in the lifecycle script verbatim rather than substituted with an empty
+# string, and the rest of the script still runs. See aws-greengrass-lite#867.
+def test_Component_29_T5(iot_obj: IoTUtils, gg_util_obj: GGTestUtils,
+                         system_interface: SystemInterface):
+    component = "SampleComponentWithMissingConfiguration"
+    recipe_dir = f"./components/{component}/1.0.0/recipe/"
+    service = f"ggl.{component}.service"
+
+    assert gg_util_obj.create_local_deployment(None, recipe_dir,
+                                               f"{component}=1.0.0")
+
+    timeout = 180
+    while timeout > 0:
+        if system_interface.check_systemctl_status_for_component(
+                component) == "RUNNING":
+            break
+        sleep_with_log(1)
+        timeout -= 1
+    assert (system_interface.check_systemctl_status_for_component(component) ==
+            "RUNNING")
+
+    # A resolvable variable is still substituted.
+    assert (system_interface.monitor_journalctl_for_message(
+        service, "present=MyConfigDefaultValue", timeout=30) is True)
+
+    # An unresolvable variable is left as-is instead of blanked.
+    assert (system_interface.monitor_journalctl_for_message(
+        service, "missing={configuration:/NoSuchKey}", timeout=30) is True)
+
+    # The line after the unresolvable variable still runs, so interpolation did
+    # not truncate the script.
+    assert (system_interface.monitor_journalctl_for_message(service,
+                                                            "TAIL_REACHED",
+                                                            timeout=30) is True)
+
+
 # As an operator, GetConfiguration and SubscribeToConfigurationUpdate requests
 # for aws.greengrass.Nucleus are transparently forwarded to
 # aws.greengrass.NucleusLite on Greengrass Lite, and subscribe events are


### PR DESCRIPTION
**Issue #, if available:**

aws-greengrass/aws-greengrass-lite#867

**Description of changes:**

Adds a UAT covering recipe-variable interpolation when the referenced
configuration value does not exist.

- New component `SampleComponentWithMissingConfiguration` whose `run` lifecycle
  references an existing key, a nonexistent key, and then a marker line.
- New test `test_Component_29_T5`, deployed locally via
  `create_local_deployment` (no cloud upload needed).

Placed under requirement 29, which is the configuration-interpolation
requirement ("As an operator, I can interpolate component default configurations
by local deployment" — `29_T0`, and config updates from multiple sources —
`29_T4`). `T5` is the next unused variant, chosen rather than `T1`-`T3` so it
cannot collide with a case that is defined in the test plan but not yet
implemented here. Naming follows `test_{Category}_{TestNumber}_T{Variant}` per
the README, and the test sits with the rest of the 29 family in file order.

Three assertions: a resolvable variable is still substituted; an unresolvable
one appears verbatim as `{configuration:/NoSuchKey}`; and the line after it
still runs.

**Why is this change necessary:**

Nucleus lite propagated the config reader's `GG_ERR_NOENTRY` out of
interpolation, truncating the generated lifecycle script at that point. Nothing
in UAT covered it.

The variable is deliberately **unquoted**, which is the placement that fails
silently — the truncated line is still a valid command, so it runs and emits an
empty value while every following line is dropped. Quoted, the same truncation
leaves an unterminated string and the shell rejects the script outright. A
quoted-only test would only catch the loud case, so this test covers the quiet
one and the marker line detects the dropped remainder.

Per the AWS IoT Greengrass V2 recipe reference, a JSON pointer resolving to no
node should leave the recipe variable unreplaced.

**How was this change tested:**

The behaviour under test was verified end to end on an EC2 device (Ubuntu 24.04,
`.deb` built on the device) against nucleus lite built at both revisions, with
the same component deployed to each:

| | without the fix | with the fix |
|---|---|---|
| resolvable pointer | substituted | substituted |
| unresolvable, unquoted | `missing=` (blank) | `missing={configuration:/NoSuchKey}` |
| line after the variable | dropped | present |

`yapf --style pyproject.toml` reports no diff and `python3 -m py_compile` passes.
The change is purely additive — no existing line is modified.

**Any additional information or context required to review the change:**

Note that requirement 29's existing coverage is currently disabled: both
`component:test_Component_29_T0` and `component:test_Component_29_T4` are listed
in the lite repo's `.github/uat-ignore.txt`. `29_T5` is not ignored, so it will
run.

**Merge ordering:** this test fails against nucleus lite `main` today, because
the fix is not merged yet. Please merge
aws-greengrass/aws-greengrass-lite#1162 first, or land this together with it —
otherwise UAT goes red for everyone in between. The alternative is adding
`component:test_Component_29_T5` to the lite repo's `.github/uat-ignore.txt` and
removing it in #1162, but sequencing the merges is simpler.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
